### PR TITLE
enable coverage search with all sensor types

### DIFF
--- a/geosys/bridge_api/definitions.py
+++ b/geosys/bridge_api/definitions.py
@@ -287,3 +287,9 @@ SENTINEL_2 = {
 SENSORS = [
     DEIMOS, DMC, LANDSAT_8, RESOURCESAT2, SENTINEL_2
 ]
+
+ALL_SENSORS = {
+    'key': 'ALL_SENSORS',
+    'name': 'ALL SENSORS',
+    'sensors': SENSORS
+}

--- a/geosys/ui/widgets/geosys_coverage_downloader.py
+++ b/geosys/ui/widgets/geosys_coverage_downloader.py
@@ -82,9 +82,11 @@ class CoverageSearchThread(QThread):
 
         self.filters = {
             MAPS_TYPE: self.map_product,
-            IMAGE_SENSOR: self.sensor_type,
             IMAGE_DATE: date_filter
         }
+        self.sensor_type and self.filters.update({
+            IMAGE_SENSOR: self.sensor_type
+        })
 
         self.settings = QSettings()
 

--- a/geosys/utilities/gui_utilities.py
+++ b/geosys/utilities/gui_utilities.py
@@ -40,6 +40,20 @@ def layer_from_combo(combo):
     return layer
 
 
+def item_data_from_combo(combo):
+    """Get the item data currently selected in a combo box.
+
+    :returns: The currently selected combo box item data.
+    :rtype: any
+    """
+    index = combo.currentIndex()
+    if index < 0:
+        return None
+
+    item_data = combo.itemData(index, Qt.UserRole)
+    return item_data
+
+
 def add_ordered_combo_item(
         combo, text, data=None, count_selected_features=None, icon=None):
     """Add a combo item ensuring that all items are listed alphabetically.


### PR DESCRIPTION
fix #35 
when `ALL SENSORS` is selected, it will not use sensor filter when requesting a coverage search