### PR TITLE
handle multi polygon coverage request

### DIFF
--- a/geosys/ui/templates/geosys_dockwidget_base.ui
+++ b/geosys/ui/templates/geosys_dockwidget_base.ui
@@ -115,7 +115,7 @@
            <item>
             <widget class="QCheckBox" name="single_geometry_checkbox">
              <property name="text">
-              <string>Features as single geometry</string>
+              <string>Bulk request (all objects as a single geometry)</string>
              </property>
             </widget>
            </item>

--- a/geosys/ui/templates/geosys_dockwidget_base.ui
+++ b/geosys/ui/templates/geosys_dockwidget_base.ui
@@ -13,7 +13,7 @@
   <property name="minimumSize">
    <size>
     <width>466</width>
-    <height>474</height>
+    <height>477</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -109,6 +109,13 @@
              </property>
              <property name="text">
               <string>Selected features only</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="single_geometry_checkbox">
+             <property name="text">
+              <string>Features as single geometry</string>
              </property>
             </widget>
            </item>

--- a/geosys/ui/widgets/geosys_dockwidget.py
+++ b/geosys/ui/widgets/geosys_dockwidget.py
@@ -51,7 +51,7 @@ from geosys.ui.widgets.geosys_coverage_downloader import (
 from geosys.ui.widgets.geosys_itemwidget import CoverageSearchResultItemWidget
 from geosys.utilities.gui_utilities import (
     add_ordered_combo_item, layer_icon, is_polygon_layer, layer_from_combo,
-    add_layer_to_canvas, reproject, item_data_from_combo)
+    add_layer_to_canvas, reproject, item_data_from_combo, wkt_geometries_from_feature_iterator)
 from geosys.utilities.resources import get_ui_class
 from geosys.utilities.settings import setting, set_setting
 
@@ -82,7 +82,7 @@ class GeosysPluginDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         self.current_stacked_widget_index = 0
 
         # Coverage parameters from input values
-        self.geometry_wkt = None
+        self.wkt_geometries = None
         self.map_product = None
         self.sensor_type = None
         self.start_date = None
@@ -190,8 +190,8 @@ class GeosysPluginDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         """Open next page of stacked widget."""
         # If current page is coverage parameters page, run coverage searcher.
         if self.current_stacked_widget_index == 0:
-            self.next_push_button.setEnabled(False)
             self.start_coverage_search()
+            self.next_push_button.setEnabled(False)
 
         # If current page is coverage results page, prepare map creation
         # parameters.
@@ -371,6 +371,7 @@ class GeosysPluginDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         use_selected_features = (
             self.selected_features_checkbox.isChecked() and (
                 layer.selectedFeatureCount() > 0))
+        use_single_geometry = self.single_geometry_checkbox.isChecked()
 
         # Reproject layer to EPSG:4326
         if layer.crs().authid() != 'EPSG:4326':
@@ -386,20 +387,10 @@ class GeosysPluginDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         # Handle multi features
         # Merge features into multi-part polygon
         # TODO use Collect Geometries processing algorithm
-        geom = None
-        for index, feature in enumerate(feature_iterator):
-            if index >= MAX_FEATURE_NUMBERS:
-                break
-            if not feature.hasGeometry():
-                continue
-            if not geom:
-                geom = feature.geometry()
-            else:
-                geom = geom.combine(feature.geometry())
+        self.wkt_geometries = wkt_geometries_from_feature_iterator(
+            feature_iterator, MAX_FEATURE_NUMBERS, use_single_geometry)
 
-        if geom:
-            self.geometry_wkt = geom.asWkt()
-        else:
+        if not self.wkt_geometries:
             # geometry is not valid
             return False, 'Geometry is not valid.'
 
@@ -567,7 +558,7 @@ class GeosysPluginDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
 
         # start search thread
         searcher = CoverageSearchThread(
-            geometry=self.geometry_wkt,
+            geometries=self.wkt_geometries,
             crop_type=self.crop_type,
             sowing_date=self.sowing_date,
             map_product=self.map_product,

--- a/geosys/ui/widgets/geosys_dockwidget.py
+++ b/geosys/ui/widgets/geosys_dockwidget.py
@@ -224,8 +224,20 @@ class GeosysPluginDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
     def handle_difference_map_button(self):
         """Handle difference map button behavior."""
         if self.current_stacked_widget_index == 2:
-            # show difference map button only if 2 items are being selected
-            if len(self.selected_coverage_results) == 2 and (
+            # Show difference map button only if 2 items are being selected
+            # and has same SeasonField ID.
+
+            # check SeasonField ID
+            has_same_id = False
+            season_field_id = None
+            for coverage_result in self.selected_coverage_results:
+                if not season_field_id:
+                    season_field_id = coverage_result['seasonField']['id']
+                else:
+                    has_same_id = season_field_id == (
+                        coverage_result['seasonField']['id'])
+
+            if len(self.selected_coverage_results) == 2 and has_same_id and (
                     self.map_product in [
                         INSEASON_NDVI['key'], INSEASON_EVI['key']]):
                 self.difference_map_push_button.setVisible(True)

--- a/geosys/utilities/gui_utilities.py
+++ b/geosys/utilities/gui_utilities.py
@@ -308,3 +308,44 @@ def reproject(layer, output_crs):
 
     reprojected.commitChanges()
     return reprojected
+
+
+def wkt_geometries_from_feature_iterator(
+        feature_iterator, max_features=None, as_single_geometry=False):
+    """Get list of wkt geometries from a QgsMapLayer feature iterator.
+
+    :param feature_iterator: QGIS layer feature iterator.
+        *retrieved from QgsMapLayer.getFeatures()
+    :type feature_iterator: QgsFeatureIterator
+
+    :param max_features: Number of maximum features iteration.
+    :type max_features: int
+
+    :param as_single_geometry: Flag indicating whether to squash the features
+        into single geometry or not.
+    :type as_single_geometry: bool
+
+    :return: List of wkt geometries.
+    :rtype: list
+    """
+    geom = None
+    geoms = []
+    for index, feature in enumerate(feature_iterator):
+        if index >= max_features:
+            break
+        if not feature.hasGeometry():
+            continue
+        if as_single_geometry:
+            if not geom:
+                geom = feature.geometry()
+            else:
+                geom = geom.combine(feature.geometry())
+        else:
+            geoms.append(feature.geometry())
+
+    if geom:
+        return [geom.asWkt()]
+    elif geoms:
+        return [geom.asWkt() for geom in geoms]
+    else:
+        return []


### PR DESCRIPTION
fix #70 

<img width="466" alt="Screen Shot 2019-05-14 at 03 40 13" src="https://user-images.githubusercontent.com/11134669/57652543-0359c780-75fa-11e9-9b52-9e79dcec4c66.png">

I added new checkbox option to combine all features into one geometry. If this option is unticked, then it will run multi polygon coverage request.

*applying this feature to processing algs will break the behaviour of the algs since its only expecting one output layer so it could be used by QGIS Modeler. cc @VincentLel @timlinux @AndreLester 