### PR TITLE
API URLs updated

### DIFF
--- a/geosys/bridge_api/default.py
+++ b/geosys/bridge_api/default.py
@@ -28,7 +28,7 @@ IDENTITY_URLS = {
         'prod': 'https://identity.geosys-na.com'
     },
     'eu': {
-        'test': 'https://identity.preprod.geosys-na.com',
+        'test': 'https://identity.preprod.geosys-eu.com',
         'prod': 'https://identity.geosys-eu.com'
     }
 }

--- a/geosys/bridge_api/default.py
+++ b/geosys/bridge_api/default.py
@@ -28,18 +28,18 @@ IDENTITY_URLS = {
         'prod': 'https://identity.geosys-na.com'
     },
     'eu': {
-        'test': 'https://identity.preprod.geosys-eu.com',
+        'test': 'https://identity.preprod.geosys-na.com',
         'prod': 'https://identity.geosys-eu.com'
     }
 }
 BRIDGE_URLS = {
     'na': {
-        'test': 'https://bridge.preprod.geosys-na.com',
-        'prod': 'https://bridge.geosys-na.com'
+        'test': 'http://api-pp.geosys-na.net',
+        'prod': 'http://api.geosys-na.net'
     },
     'eu': {
-        'test': 'https://bridge.preprod.geosys-eu.com',
-        'prod': 'https://bridge.geosys-eu.com'
+        'test': 'http://api-pp.geosys-na.net',
+        'prod': 'http://api.geosys-eu.net'
     }
 }
 


### PR DESCRIPTION
API URLs updated to make use of the following:
IDENTITY_URLS = {   
'na': {
        'test': 'https://identity.preprod.geosys-na.com/v2.1',
        'prod': 'https://identity.geosys-na.com/v2.1'
    },
    'eu': {
        'test': 'https://identity.preprod.geosys-na.com/v2.1'
        'prod': 'https://identity.geosys-eu.com/v2.1'
    }
}
GEOSYS_API_URLS = {
    'na': {
        'test': 'http://api-pp.geosys-na.net',
        'prod': 'http://api.geosys-na.net'
    },
    'eu': {
        'test': 'http://api-pp.geosys-na.net',
        'prod': 'http://api.geosys-eu.net'
    }
}