### PR TITLE
Default number of zones value changed from 5 to 0

### DIFF
--- a/geosys/bridge_api/default.py
+++ b/geosys/bridge_api/default.py
@@ -48,7 +48,7 @@ CLIENT_SECRET = 'mapproduct_api.secret'
 GRANT_TYPE = 'password'
 SCOPE = 'openid offline_access'
 MAX_FEATURE_NUMBERS = 10
-DEFAULT_ZONE_COUNT = 5
+DEFAULT_ZONE_COUNT = 0
 
 # coverage filters
 


### PR DESCRIPTION
Fixes #131 
The default value for "Number of Zones" will no longer be 5 but 0.
![image](https://user-images.githubusercontent.com/79740955/151136207-53ab9ca4-86d8-4e66-b4d0-d6bd67c29f91.png)
