### PR TITLE
Dev map type defs

### DIFF
--- a/geosys/bridge_api/definitions.py
+++ b/geosys/bridge_api/definitions.py
@@ -64,14 +64,6 @@ yield_variability_map = {
     'key': 'yield-variability-map',
     'endpoint': 'yield-variability-map'
 }
-soil_map = {
-    'key': 'soilmap',
-    'endpoint': 'soilmap'
-}
-reflectance_map = {
-    'key': 'reflectance-map',
-    'endpoint': 'reflectance-map'
-}
 
 # Map types definition
 
@@ -216,25 +208,6 @@ INSEASON_CVIN = {
     'description': 'Provides the in-season Chlorophyll Vegetation Index normalized.'
 }
 
-# Soil
-SOIL = {
-    'key': 'SOIL',
-    'name': 'SOIL',
-    'map_family': soil_map,
-    'description': 'Provides the in-season Soil type map. '
-                   'Can be generated only in the USA, contains '
-                   'information about soil as collected by the '
-                   'National Cooperative Soil Survey.'
-}
-
-# Reflectance
-REFLECTANCE = {
-    'key': 'REFLECTANCE',
-    'name': 'REFLECTANCE',
-    'map_family': reflectance_map,
-    'description': 'Provides the reflectance at Top of Canopy for Sentinel 2 and Landsat-8.'
-}
-
 # OM (Organic Matter)
 OM = {
     'key': 'OM',
@@ -314,9 +287,7 @@ ARCHIVE_MAP_PRODUCTS = [
     OM,
     YGM,
     YVM,
-    SAMZ,
-    SOIL,
-    REFLECTANCE
+    SAMZ
 ]
 
 BASIC_INSEASON_MAP_PRODUCTS = [

--- a/geosys/bridge_api/definitions.py
+++ b/geosys/bridge_api/definitions.py
@@ -64,6 +64,14 @@ yield_variability_map = {
     'key': 'yield-variability-map',
     'endpoint': 'yield-variability-map'
 }
+soil_map = {
+    'key': 'soilmap',
+    'endpoint': 'soilmap'
+}
+reflectance_map = {
+    'key': 'reflectance-map',
+    'endpoint': 'reflectance-map'
+}
 
 # Map types definition
 
@@ -81,12 +89,6 @@ DIFFERENCE_INSEASON_EVI = {
 
 # NDVI (Normalized Difference Vegetation Index)
 # https://en.wikipedia.org/wiki/Normalized_difference_vegetation_index
-NDVI = {
-    'key': 'NDVI',
-    'name': 'NDVI',
-    'map_family': base_reference_map,
-    'description': 'Provides the Normalized Difference Vegetation Index.'
-}
 INSEASON_NDVI = {
     'key': 'INSEASON_NDVI',
     'name': 'INSEASON_NDVI',
@@ -196,6 +198,42 @@ INSEASONFIELD_AVERAGE_REVERSE_LAI = {
     'description': ''
 }
 
+# Sentinel-2 Red-edge position index (S2REP)
+INSEASON_S2REP = {
+    'key': 'INSEASON_S2REP',
+    'name': 'INSEASON_S2REP',
+    'map_family': base_reference_map,
+    'description': 'Provides the in-season S2REP index. '
+                   'Generates a map according to the amount '
+                   'of chlorophyll content per unit of leaf (LCC).'
+}
+
+# Chlorophyll vegetation index
+INSEASON_CVIN = {
+    'key': 'INSEASON_CVIN',
+    'name': 'INSEASON_CVIN',
+    'map_family': base_reference_map,
+    'description': 'Provides the in-season Chlorophyll Vegetation Index normalized.'
+}
+
+# Soil
+SOIL = {
+    'key': 'SOIL',
+    'name': 'SOIL',
+    'map_family': soil_map,
+    'description': 'Provides the in-season Soil type map. '
+                   'Can be generated only in the USA, contains '
+                   'information about soil as collected by the '
+                   'National Cooperative Soil Survey.'
+}
+
+# Reflectance
+REFLECTANCE = {
+    'key': 'REFLECTANCE',
+    'name': 'REFLECTANCE',
+    'map_family': reflectance_map,
+    'description': 'Provides the reflectance at Top of Canopy for Sentinel 2 and Landsat-8.'
+}
 
 # OM (Organic Matter)
 OM = {
@@ -264,13 +302,21 @@ ARCHIVE_MAP_PRODUCTS = [
     INSEASON_CVI,
     INSEASONPARTIAL_NDVI,
     INSEASONPARTIAL_EVI,
+    INSEASON_LAI,
+    INSEASONFIELD_AVERAGE_NDVI,
+    INSEASONFIELD_AVERAGE_LAI,
+    INSEASONFIELD_AVERAGE_REVERSE_NDVI,
+    INSEASONFIELD_AVERAGE_REVERSE_LAI,
+    INSEASON_S2REP,
+    INSEASON_CVIN,
     COLOR_COMPOSITION,
     ELEVATION,
     OM,
     YGM,
     YVM,
     SAMZ,
-    NDVI
+    SOIL,
+    REFLECTANCE
 ]
 
 BASIC_INSEASON_MAP_PRODUCTS = [
@@ -278,12 +324,15 @@ BASIC_INSEASON_MAP_PRODUCTS = [
     INSEASON_EVI,
     INSEASON_CVI,
     INSEASON_GNDVI,
-    INSEASON_LAI
+    INSEASON_LAI,
+    INSEASON_S2REP
 ]
 
 INSEASON_MAP_PRODUCTS = BASIC_INSEASON_MAP_PRODUCTS + [
     INSEASONFIELD_AVERAGE_NDVI,
     INSEASONFIELD_AVERAGE_REVERSE_NDVI,
+    INSEASONFIELD_AVERAGE_LAI,
+    INSEASONFIELD_AVERAGE_REVERSE_LAI,
     INSEASONPARTIAL_NDVI,
     INSEASONPARTIAL_EVI,
 ]
@@ -311,8 +360,9 @@ DMC = {
 LANDSAT_8 = {
     'key': 'LANDSAT_8',
     'name': 'LANDSAT_8',
-    'description': 'Providing moderate-resolution imagery, '
-                   'from 15 meters to 100 meters.'
+    'description': 'Providing moderate-resolution imagery at 30 meters '
+                   'resampled to 15 meters by Geosys. Revisiting every '
+                   '16 days.'
 }
 
 RESOURCESAT2 = {
@@ -320,7 +370,8 @@ RESOURCESAT2 = {
     'name': 'RESOURCESAT2',
     'description': 'The Linear Imaging Self-Scanning Sensor (LISS-III) '
                    'with 23.5 meter spatial resolution LISS-IV Camera with '
-                   '5.8 meter spatial resolution.'
+                   '5.8 meter spatial resolution. '
+                   'Revisiting every 24 days.'
 }
 
 SENTINEL_2 = {


### PR DESCRIPTION
Fixes #126. Fixes #132. Fixes #129. Fixes #128. Fixes #124.
These changes relates to the changes in the defintions.py file for the map types.
NDVI has been removed, S2REP has been added, nitrogen map types added, and CVIN map types added.

Reflectance map type has been added, but only the Landsat and S2 sensors should be selectable (https://github.com/GEOSYS/qgis-plugin/issues/125).
Soil option has been added, but should only be available when the US area has been selected (https://github.com/GEOSYS/qgis-plugin/issues/123).