### PR TITLE
Reflectance map type added

### DIFF
--- a/geosys/bridge_api/definitions.py
+++ b/geosys/bridge_api/definitions.py
@@ -64,6 +64,10 @@ yield_variability_map = {
     'key': 'yield-variability-map',
     'endpoint': 'yield-variability-map'
 }
+reflectance_map = {
+    'key': 'reflectance-map',
+    'endpoint': 'reflectance-map'
+}
 
 # Map types definition
 
@@ -208,6 +212,14 @@ INSEASON_CVIN = {
     'description': 'Provides the in-season Chlorophyll Vegetation Index normalized.'
 }
 
+# Top of canopy reflectance
+REFLECTANCE = {
+    'key': 'TOC',
+    'name': 'REFLECTANCE',
+    'map_family': reflectance_map,
+    'description': 'Top of canopy reflectance based on either Sentinel-2 or Landsat-8.'
+}
+
 # OM (Organic Matter)
 OM = {
     'key': 'OM',
@@ -282,6 +294,7 @@ ARCHIVE_MAP_PRODUCTS = [
     INSEASONFIELD_AVERAGE_REVERSE_LAI,
     INSEASON_S2REP,
     INSEASON_CVIN,
+    REFLECTANCE,
     COLOR_COMPOSITION,
     ELEVATION,
     OM,

--- a/geosys/ui/widgets/geosys_dockwidget.py
+++ b/geosys/ui/widgets/geosys_dockwidget.py
@@ -758,6 +758,36 @@ class GeosysPluginDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
 
         self.iface.mapCanvas().layersChanged.disconnect(self.get_layers)
 
+    def populate_sensors_reflectance(self):
+        """Obtain a list of sensors from Bridge API definition.
+        For reflectance TOC, so only Landsat-8 and Sentinel-8 should be included, otherwise all of the sensors
+        """
+        for sensor in [ALL_SENSORS]+SENSORS:
+            sensor_name = sensor['name']
+            if sensor_name == 'LANDSAT_8' or sensor_name == 'SENTINEL_2':
+                add_ordered_combo_item(self.sensor_combo_box, sensor_name, sensor['key'])
+
+    def clear_combo_box(self, combo_box):
+        """Clears/removes all of the entries in the provided combo_box
+
+        :param combo_box: Combobox for which all of the entries should be removed
+        :type combo_box: QComboBox
+        """
+        cnt = combo_box.count()
+        while cnt >= 0:
+            combo_box.removeItem(cnt)
+
+            cnt = cnt - 1
+
+    def product_type_change(self):
+        map_product = self.map_product_combo_box.currentText()
+        if map_product == 'REFLECTANCE':  # If TOC reflectance has been chosen, only Sentinel-2 and Landsat-8 will be available as an option
+            self.clear_combo_box(self.sensor_combo_box)
+            self.populate_sensors_reflectance()
+        else:
+            self.clear_combo_box(self.sensor_combo_box)
+            self.populate_sensors()
+
     def setup_connectors(self):
         """Setup signal/slot mechanisms for dock elements."""
         # Button connector
@@ -766,6 +796,9 @@ class GeosysPluginDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         self.next_push_button.clicked.connect(self.show_next_page)
         self.difference_map_push_button.clicked.connect(
             self.start_difference_map_creation)
+
+        # Product type has changed
+        self.map_product_combo_box.currentIndexChanged.connect(self.product_type_change)
 
         # Stacked widget connector
         self.stacked_widget.currentChanged.connect(self.set_next_button_text)


### PR DESCRIPTION
Fixes #125 

Reflectance map type has been added to the definitions and is now available as an option.
When the 'REFLECTANCE' product has been chosen by the user, only the 'LANDSAT-8' and 'SENTINEL-2' sensors will be available to choose from.

Reflectance option added
![image](https://user-images.githubusercontent.com/79740955/153185560-15b33576-3d7e-43a4-9c2c-22b25ad34cf2.png)


Only L8 and S2 sensors available
![image](https://user-images.githubusercontent.com/79740955/153185669-42beaaf1-962a-4736-8fdd-0d4b2c00fa61.png)
