### PR TITLE
Soil map type

### DIFF
--- a/geosys/bridge_api/definitions.py
+++ b/geosys/bridge_api/definitions.py
@@ -68,6 +68,10 @@ reflectance_map = {
     'key': 'reflectance-map',
     'endpoint': 'reflectance-map'
 }
+samplemap = {
+    'key': 'sample',
+    'endpoint': 'sample'
+}
 
 # Map types definition
 
@@ -280,6 +284,14 @@ SLOPE = {
     'description': 'Provides the slope map.'
 }
 
+# Soil map
+SOIL = {
+    'key': 'SOILMAP',
+    'name': 'SOILMAP',
+    'map_family': samplemap,
+    'description': 'Provides the soil map.'
+}
+
 ARCHIVE_MAP_PRODUCTS = [
     INSEASON_NDVI,
     INSEASON_GNDVI,
@@ -297,6 +309,7 @@ ARCHIVE_MAP_PRODUCTS = [
     REFLECTANCE,
     COLOR_COMPOSITION,
     ELEVATION,
+    SOIL,
     OM,
     YGM,
     YVM,

--- a/geosys/bridge_api/definitions.py
+++ b/geosys/bridge_api/definitions.py
@@ -64,7 +64,6 @@ yield_variability_map = {
     'key': 'yield-variability-map',
     'endpoint': 'yield-variability-map'
 }
-
 reflectance_map = {
     'key': 'reflectance-map',
     'endpoint': 'reflectance-map'

--- a/geosys/bridge_api/definitions.py
+++ b/geosys/bridge_api/definitions.py
@@ -64,6 +64,7 @@ yield_variability_map = {
     'key': 'yield-variability-map',
     'endpoint': 'yield-variability-map'
 }
+
 reflectance_map = {
     'key': 'reflectance-map',
     'endpoint': 'reflectance-map'

--- a/geosys/bridge_api/definitions.py
+++ b/geosys/bridge_api/definitions.py
@@ -286,8 +286,8 @@ SLOPE = {
 
 # Soil map
 SOIL = {
-    'key': 'SOILMAP',
-    'name': 'SOILMAP',
+    'key': 'SOIL',
+    'name': 'SOIL',
     'map_family': samplemap,
     'description': 'Provides the soil map.'
 }

--- a/geosys/plugin.py
+++ b/geosys/plugin.py
@@ -270,6 +270,12 @@ class GeosysPlugin:
             self.dock_widget.setVisible(True)
             self.dock_widget.raise_()
 
+    def populate_map_products(self):
+        """Obtain a list of map products from Bridge API definition.
+        If the US zone has been selected the soil option will be included, otherwise excluded.
+        """
+        self.dock_widget.populate_map_products()
+
     def show_options(self):
         """Show the options dialog."""
         # import here only so that it is AFTER i18n set up
@@ -278,4 +284,5 @@ class GeosysPlugin:
         dialog = GeosysOptionsDialog(
             self.iface, parent=self.iface.mainWindow())
         if dialog.exec_():  # modal
+            self.populate_map_products()  # Repopulates the maptypes combobox if the user clicked OK
             pass

--- a/geosys/test/test_geosys_dockwidget.py
+++ b/geosys/test/test_geosys_dockwidget.py
@@ -12,6 +12,7 @@ import unittest
 
 from geosys.test.utilities import get_qgis_app
 from geosys.ui.widgets.geosys_dockwidget import GeosysPluginDockWidget
+from geosys.utilities.settings import setting
 from PyQt5.QtWidgets import QComboBox
 
 __copyright__ = "Copyright 2019, Kartoza"
@@ -40,17 +41,39 @@ class GeosysPluginDockWidgetTest(unittest.TestCase):
     def test_clear_combo_box(self):
         """Test if the clear_combo_box method works as it should."""
 
-        test_list = ['First', 'Second', 'Third']
+        test_list = ['First', 'Second', 'Third']  # A list of items which will be added to the combobox
         test_cb = QComboBox()
         test_cb.addItems(test_list)
 
-        GeosysPluginDockWidget.clear_combo_box(test_cb)
+        # Clears the combobox of all items
+        GeosysPluginDockWidget.clear_combo_box(self.dockwidget, test_cb)
 
-        expected_count = 0
+        expected_count = 0  # The combobox should now be empty
         cb_count = test_cb.count()
 
-        message = 'Expected %s items in the combobox, but got %s' % (expected_count, str(cb_count))
-        self.assertEqual(expected_count, str(cb_count), message)
+        message = 'Expected %s items in the combobox, but got %s' % (str(expected_count), str(cb_count))
+        self.assertEqual(str(expected_count), str(cb_count), message)
+
+    def test_populate_map_products(self):
+        """Test whether the combobox is populated correctly.
+        If the zone is set to US, the soil map type can be included.
+        If the zone is set to EU, the soil map type should be excluded.
+        """
+
+        GeosysPluginDockWidget.populate_map_products(self.dockwidget)
+
+        key_us = 'geosys_region_na'
+        us_option = setting(key_us, expected_type=bool, qsettings=self.dockwidget.settings)
+        if us_option:  # Expected number of items for US (soil map included)
+            expected_count = 21
+        else:  # Expected number of items for EU (soil map excluded)
+            expected_count = 20
+
+        combobox = self.dockwidget.map_product_combo_box
+        cb_count = combobox.count()
+
+        message = 'Expected %s items in the combobox, but got %s' % (str(expected_count), str(cb_count))
+        self.assertEqual(str(expected_count), str(cb_count), message)
 
 
 if __name__ == "__main__":

--- a/geosys/test/test_geosys_dockwidget.py
+++ b/geosys/test/test_geosys_dockwidget.py
@@ -12,6 +12,7 @@ import unittest
 
 from geosys.test.utilities import get_qgis_app
 from geosys.ui.widgets.geosys_dockwidget import GeosysPluginDockWidget
+from PyQt5.QtWidgets import QComboBox
 
 __copyright__ = "Copyright 2019, Kartoza"
 __license__ = "GPL version 3"
@@ -35,6 +36,21 @@ class GeosysPluginDockWidgetTest(unittest.TestCase):
     def test_dockwidget_ok(self):
         """Test we can click OK."""
         pass
+
+    def test_clear_combo_box(self):
+        """Test if the clear_combo_box method works as it should."""
+
+        test_list = ['First', 'Second', 'Third']
+        test_cb = QComboBox()
+        test_cb.addItems(test_list)
+
+        GeosysPluginDockWidget.clear_combo_box(test_cb)
+
+        expected_count = 0
+        cb_count = test_cb.count()
+
+        message = 'Expected %s items in the combobox, but got %s' % (expected_count, str(cb_count))
+        self.assertEqual(expected_count, str(cb_count), message)
 
 
 if __name__ == "__main__":

--- a/geosys/ui/widgets/geosys_dockwidget.py
+++ b/geosys/ui/widgets/geosys_dockwidget.py
@@ -783,7 +783,6 @@ class GeosysPluginDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         :type combo_box: QComboBox
         """
         cnt = combo_box.count()
-
         if cnt > 0:  # Skips if there are no items in the combobox
             while cnt >= 0:
                 combo_box.removeItem(cnt)

--- a/geosys/ui/widgets/geosys_dockwidget.py
+++ b/geosys/ui/widgets/geosys_dockwidget.py
@@ -45,7 +45,7 @@ from geosys.bridge_api.default import (
     MAX_FEATURE_NUMBERS, DEFAULT_ZONE_COUNT)
 from geosys.bridge_api.definitions import (
     ARCHIVE_MAP_PRODUCTS, ALL_SENSORS, SENSORS, INSEASON_NDVI, INSEASON_EVI,
-    SAMZ, ELEVATION)
+    SAMZ, SOIL, ELEVATION)
 from geosys.bridge_api.utilities import get_definition
 from geosys.ui.help.help_dialog import HelpDialog
 from geosys.ui.widgets.geosys_coverage_downloader import (
@@ -175,7 +175,7 @@ class GeosysPluginDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
             if us_option:  # If US zone is selected the SOILMAP option will be added
                 add_ordered_combo_item(self.map_product_combo_box, map_product['name'], map_product['key'])
             else:  # If EU area is selected the SOILMAP option will not be added
-                if product_name != "SOILMAP":
+                if product_name != SOIL['name']:
                     add_ordered_combo_item(self.map_product_combo_box, map_product['name'], map_product['key'])
 
     def populate_date(self):

--- a/geosys/ui/widgets/geosys_dockwidget.py
+++ b/geosys/ui/widgets/geosys_dockwidget.py
@@ -161,12 +161,22 @@ class GeosysPluginDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
                 self.sensor_combo_box, sensor['name'], sensor['key'])
 
     def populate_map_products(self):
-        """Obtain a list of map products from Bridge API definition."""
+        """Obtain a list of map products from Bridge API definition.
+        If the US zone has been selected the soil option will be included, otherwise excluded.
+        """
+        # Checks if the US zone option is selected/activate
+        key = 'geosys_region_na'
+        us_option = setting(key, expected_type=bool, qsettings=self.settings)
+
+        self.clear_combo_box(self.map_product_combo_box)
+
         for map_product in ARCHIVE_MAP_PRODUCTS:
-            add_ordered_combo_item(
-                self.map_product_combo_box,
-                map_product['name'],
-                map_product['key'])
+            product_name = map_product['name']
+            if us_option:  # If US zone is selected the SOILMAP option will be added
+                add_ordered_combo_item(self.map_product_combo_box, map_product['name'], map_product['key'])
+            else:  # If EU area is selected the SOILMAP option will not be added
+                if product_name != "SOILMAP":
+                    add_ordered_combo_item(self.map_product_combo_box, map_product['name'], map_product['key'])
 
     def populate_date(self):
         """Set default value of start and end date to last week."""
@@ -769,15 +779,16 @@ class GeosysPluginDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
 
     def clear_combo_box(self, combo_box):
         """Clears/removes all of the entries in the provided combo_box
-
         :param combo_box: Combobox for which all of the entries should be removed
         :type combo_box: QComboBox
         """
         cnt = combo_box.count()
-        while cnt >= 0:
-            combo_box.removeItem(cnt)
 
-            cnt = cnt - 1
+        if cnt > 0:  # Skips if there are no items in the combobox
+            while cnt >= 0:
+                combo_box.removeItem(cnt)
+
+                cnt = cnt - 1
 
     def product_type_change(self):
         map_product = self.map_product_combo_box.currentText()


### PR DESCRIPTION
Fixes #123 
Option for soil map type available.
The option will not be available if the EU zone has been selected; will always be available for the US zones.
This works for when QGIS starts up, is activated in the manager, and if the options is changed by the user.

US zone (soil option included):
![image](https://user-images.githubusercontent.com/79740955/153395518-7ecfabf8-1ba0-4431-b5ff-da43150dfb5b.png)

EU zone (soil option excluded):
![image](https://user-images.githubusercontent.com/79740955/153395622-3a1df911-9e9b-4a87-b85a-383eb6ae3585.png)
