### PR TITLE
Gain and offset parameters for map creation

### DIFF
--- a/geosys/bridge_api/default.py
+++ b/geosys/bridge_api/default.py
@@ -70,6 +70,8 @@ SAMZ_ZONE = 'zoneCount'
 SAMZ_ZONING = 'zoning'
 HOTSPOT = 'hotspot'
 ZONING_SEGMENTATION = 'zoningSegmentation'
+GAIN = 'gain'
+OFFSET = 'offset'
 
 # map output format based on Bridge API
 

--- a/geosys/ui/templates/geosys_dockwidget_base.ui
+++ b/geosys/ui/templates/geosys_dockwidget_base.ui
@@ -262,24 +262,25 @@
       </widget>
       <widget class="QWidget" name="map_creation_page">
        <layout class="QVBoxLayout" name="verticalLayout_4">
-        <property name="leftMargin">
-         <number>3</number>
-        </property>
-        <property name="topMargin">
-         <number>3</number>
-        </property>
-        <property name="rightMargin">
-         <number>3</number>
-        </property>
-        <property name="bottomMargin">
-         <number>3</number>
-        </property>
         <item>
          <widget class="QGroupBox" name="parameters_group">
           <property name="title">
            <string>Parameters</string>
           </property>
-          <layout class="QFormLayout" name="formLayout">
+          <layout class="QGridLayout" name="gridLayout">
+           <item row="0" column="0">
+            <widget class="QLabel" name="yield_average_label">
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>Yield average</string>
+             </property>
+            </widget>
+           </item>
            <item row="0" column="1">
             <widget class="QDoubleSpinBox" name="yield_average_form">
              <property name="sizePolicy">
@@ -406,18 +407,25 @@
              </property>
             </widget>
            </item>
-           <item row="0" column="0">
-            <widget class="QLabel" name="yield_average_label">
-             <property name="minimumSize">
-              <size>
-               <width>0</width>
-               <height>0</height>
-              </size>
-             </property>
+           <item row="5" column="0">
+            <widget class="QLabel" name="gain_label">
              <property name="text">
-              <string>Yield average</string>
+              <string>Gain</string>
              </property>
             </widget>
+           </item>
+           <item row="5" column="1">
+            <widget class="QDoubleSpinBox" name="spinBox_gain"/>
+           </item>
+           <item row="6" column="0">
+            <widget class="QLabel" name="offset_label">
+             <property name="text">
+              <string>Offset</string>
+             </property>
+            </widget>
+           </item>
+           <item row="6" column="1">
+            <widget class="QDoubleSpinBox" name="spinBox_offset"/>
            </item>
           </layout>
          </widget>

--- a/geosys/ui/templates/geosys_dockwidget_base.ui
+++ b/geosys/ui/templates/geosys_dockwidget_base.ui
@@ -415,7 +415,14 @@
             </widget>
            </item>
            <item row="5" column="1">
-            <widget class="QDoubleSpinBox" name="spinBox_gain"/>
+            <widget class="QDoubleSpinBox" name="spinBox_gain">
+             <property name="decimals">
+              <number>2</number>
+             </property>
+             <property name="singleStep">
+              <double>0.100000000000000</double>
+             </property>
+            </widget>
            </item>
            <item row="6" column="0">
             <widget class="QLabel" name="offset_label">
@@ -425,7 +432,11 @@
             </widget>
            </item>
            <item row="6" column="1">
-            <widget class="QDoubleSpinBox" name="spinBox_offset"/>
+            <widget class="QDoubleSpinBox" name="spinBox_offset">
+             <property name="singleStep">
+              <double>0.100000000000000</double>
+             </property>
+            </widget>
            </item>
           </layout>
          </widget>

--- a/geosys/ui/widgets/geosys_dockwidget.py
+++ b/geosys/ui/widgets/geosys_dockwidget.py
@@ -231,14 +231,18 @@ class GeosysPluginDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
 
         for map_product_to_exclude in list_products_to_exclude:
             if selected_map_product == map_product_to_exclude:
-                # The gain and offset options will be disabled
-                self.spinBox_gain.setDisabled(True)
-                self.spinBox_offset.setDisabled(True)
+                # The gain and offset options will be hidden
+                self.gain_label.hide()
+                self.offset_label.hide()
+                self.spinBox_gain.hide()
+                self.spinBox_offset.hide()
                 return
 
-        # If the gain and offset options should be enabled
-        self.spinBox_gain.setDisabled(False)
-        self.spinBox_offset.setDisabled(False)
+        # If the gain and offset options should be shown
+        self.gain_label.show()
+        self.offset_label.show()
+        self.spinBox_gain.show()
+        self.spinBox_offset.show()
 
     def set_next_button_text(self, index):
         """Programmatically changed next button text based on current page."""

--- a/geosys/ui/widgets/geosys_dockwidget.py
+++ b/geosys/ui/widgets/geosys_dockwidget.py
@@ -203,6 +203,7 @@ class GeosysPluginDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         # If current page is coverage results page, prepare map creation
         # parameters.
         if self.current_stacked_widget_index == 1:
+            self.set_gain_offset_state()  # Disabled gain and offset for some map product types
             self.restore_parameter_values_from_setting()
 
         # If current page is map creation parameters page, create map without
@@ -218,6 +219,25 @@ class GeosysPluginDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
             self.back_push_button.setEnabled(True)
 
         self.handle_difference_map_button()
+
+    def set_gain_offset_state(self):
+        """Disables the gain and offset options in the parameters menu for the COLORCOMPOSITION, ELEVATION,
+        OM, SOILMAP, SAMZ, YGM, and YPM map product types.
+        """
+        selected_map_product = self.map_product  # Map product type selected by the user
+        list_products_to_exclude = ['COLORCOMPOSITION', 'ELEVATION', 'OM', 'SOILMAP', 'SAMZ', 'YGM', 'YPM']
+
+        for map_product_to_exclude in list_products_to_exclude:
+            if selected_map_product == map_product_to_exclude:
+                # The gain and offset options will be disabled
+                self.spinBox_gain.setDisabled(True)
+                self.spinBox_offset.setDisabled(True)
+                return
+
+        # If the gain and offset options should be enabled
+        self.spinBox_gain.setDisabled(False)
+        self.spinBox_offset.setDisabled(False)
+
 
     def set_next_button_text(self, index):
         """Programmatically changed next button text based on current page."""

--- a/geosys/utilities/downloader.py
+++ b/geosys/utilities/downloader.py
@@ -35,6 +35,16 @@ def fetch_data(url, output_path, headers=None, progress_dialog=None):
 
     :raises: ImportDialogError - when network error occurred
     """
+
+    # This is a TEMPORARY fix for a URL provided by a response from the API, which includes two filter characters (?).
+    # This fix checks if there are two filter characters and then replaces the second ? with &, which resolves the problem.
+    char_question_mark = '?'
+    list_indices = [i for i, ltr in enumerate(url) if ltr == char_question_mark]
+    if len(list_indices) > 1:
+        index = list_indices[1]
+        url = "%s%s%s" % (url[:index], '&', url[index + 1:])
+    # The TEMPORARY added fix ends here
+
     LOGGER.debug('Downloading file from URL: %s' % url)
     LOGGER.debug('Downloading to: %s' % output_path)
 


### PR DESCRIPTION
Fixes #137 
Gain and offset parameters has been added to the UI. Values starts at 0. Increases by 0.1, but value can also be typed manually.
Gain/offset will be disabled for some map product types.

Gain/offset included: Values can be provided and changed
![image](https://user-images.githubusercontent.com/79740955/154087025-649c4359-42dc-4e17-92e3-4fe717f24f1d.png)

Gain/offset disabled: Values cannot be provided or changed
![image](https://user-images.githubusercontent.com/79740955/154087287-ceedd2fd-bf64-4ef3-addb-f5fd54c311a5.png)

