### PR TITLE
Portal link description and credentials saving

### DIFF
--- a/geosys/ui/templates/options_dialog_base.ui
+++ b/geosys/ui/templates/options_dialog_base.ui
@@ -36,8 +36,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>549</width>
-        <height>804</height>
+        <width>546</width>
+        <height>636</height>
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout_3">
@@ -176,17 +176,23 @@
             </property>
            </widget>
           </item>
-          <item row="5" column="0" colspan="2">
-           <widget class="QCheckBox" name="save_credentials_checkbox">
-            <property name="text">
-             <string>Save Credentials</string>
-            </property>
-           </widget>
-          </item>
           <item row="5" column="2">
            <widget class="QPushButton" name="connect_button">
             <property name="text">
              <string>Connect</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QLabel" name="visit_geosys_label">
+            <property name="text">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://earthdailyagro.com/geosys-api/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Visit EarthDaily agro website to get your credentials&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::AutoText</enum>
+            </property>
+            <property name="openExternalLinks">
+             <bool>true</bool>
             </property>
            </widget>
           </item>
@@ -368,19 +374,6 @@
      </widget>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="visit_geosys_label">
-     <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://earthdailyagro.com/geosys-api/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Visit GEOSYS website to get your credentials&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="textFormat">
-      <enum>Qt::AutoText</enum>
-     </property>
-     <property name="openExternalLinks">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
    <item row="2" column="0">
     <layout class="QGridLayout" name="gridLayout_2">
      <item row="0" column="1">
@@ -420,7 +413,6 @@
  <tabstops>
   <tabstop>username_form</tabstop>
   <tabstop>password_form</tabstop>
-  <tabstop>save_credentials_checkbox</tabstop>
   <tabstop>connect_button</tabstop>
   <tabstop>us_radio_button</tabstop>
   <tabstop>eu_radio_button</tabstop>

--- a/geosys/ui/templates/options_dialog_base.ui
+++ b/geosys/ui/templates/options_dialog_base.ui
@@ -20,6 +20,40 @@
    <string>GEOSYS Options</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_8">
+   <item row="2" column="0">
+    <layout class="QGridLayout" name="gridLayout_2">
+     <item row="0" column="1">
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="0" column="2">
+      <widget class="QDialogButtonBox" name="button_box">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QPushButton" name="about_button">
+       <property name="text">
+        <string>About</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
    <item row="0" column="0">
     <widget class="QScrollArea" name="scrollArea">
      <property name="frameShape">
@@ -58,8 +92,8 @@
          <property name="title">
           <string>User Credentials</string>
          </property>
-         <layout class="QGridLayout" name="gridLayout_5">
-          <item row="0" column="0" colspan="3">
+         <layout class="QGridLayout" name="gridLayout_10">
+          <item row="0" column="0" colspan="2">
            <widget class="QLabel" name="credentials_label">
             <property name="text">
              <string>Use valid credentials from GEOSYS. The credentials are required to get the access token which will be used for every Bridge API request.</string>
@@ -76,7 +110,7 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="1" colspan="2">
+          <item row="1" column="1">
            <widget class="QLineEdit" name="username_form">
             <property name="minimumSize">
              <size>
@@ -99,7 +133,7 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="1" colspan="2">
+          <item row="2" column="1">
            <widget class="QLineEdit" name="password_form">
             <property name="minimumSize">
              <size>
@@ -128,7 +162,7 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="1" colspan="2">
+          <item row="3" column="1">
            <widget class="QLineEdit" name="client_id_form">
             <property name="minimumSize">
              <size>
@@ -157,7 +191,7 @@
             </property>
            </widget>
           </item>
-          <item row="4" column="1" colspan="2">
+          <item row="4" column="1">
            <widget class="QLineEdit" name="client_secret_form">
             <property name="minimumSize">
              <size>
@@ -176,25 +210,42 @@
             </property>
            </widget>
           </item>
-          <item row="5" column="2">
-           <widget class="QPushButton" name="connect_button">
-            <property name="text">
-             <string>Connect</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="1">
-           <widget class="QLabel" name="visit_geosys_label">
-            <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://earthdailyagro.com/geosys-api/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Visit EarthDaily agro website to get your credentials&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="textFormat">
-             <enum>Qt::AutoText</enum>
-            </property>
-            <property name="openExternalLinks">
-             <bool>true</bool>
-            </property>
-           </widget>
+          <item row="5" column="0" colspan="2">
+           <layout class="QGridLayout" name="gridLayout_5">
+            <item row="0" column="0">
+             <widget class="QLabel" name="visit_geosys_label">
+              <property name="text">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://earthdailyagro.com/geosys-api/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Visit EarthDaily agro website to get your credentials&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="textFormat">
+               <enum>Qt::AutoText</enum>
+              </property>
+              <property name="openExternalLinks">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="2">
+             <widget class="QPushButton" name="connect_button">
+              <property name="text">
+               <string>Connect</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <spacer name="horizontalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
           </item>
          </layout>
         </widget>
@@ -373,40 +424,6 @@
       </layout>
      </widget>
     </widget>
-   </item>
-   <item row="2" column="0">
-    <layout class="QGridLayout" name="gridLayout_2">
-     <item row="0" column="1">
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item row="0" column="2">
-      <widget class="QDialogButtonBox" name="button_box">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="standardButtons">
-        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="0">
-      <widget class="QPushButton" name="about_button">
-       <property name="text">
-        <string>About</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
    </item>
   </layout>
  </widget>

--- a/geosys/ui/widgets/options_dialog.py
+++ b/geosys/ui/widgets/options_dialog.py
@@ -48,7 +48,6 @@ class GeosysOptionsDialog(QtWidgets.QDialog, FORM_CLASS):
         self.boolean_settings = {
             'geosys_region_na': self.us_radio_button,
             'geosys_region_eu': self.eu_radio_button,
-            'save_credentials': self.save_credentials_checkbox,
             'use_testing_service': self.testing_service_checkbox
         }
         self.credentials_settings = {
@@ -284,11 +283,6 @@ class GeosysOptionsDialog(QtWidgets.QDialog, FORM_CLASS):
         # Save boolean settings
         for key, check_box in list(self.boolean_settings.items()):
             self.save_boolean_setting(key, check_box)
-
-        if not self.save_credentials_checkbox.isChecked():
-            for key in self.credentials_settings.keys():
-                del text_settings[key]
-                set_setting(key, '')
 
         # Save text settings
         for key, line_edit in list(self.text_settings.items()):


### PR DESCRIPTION
Fixes #160 
The portal link description has been updated to refer to EarthDaily agro.
The portal link has been moved to the user credentials section.
The Save credential button has been removed. Credentials will always save.

![image](https://user-images.githubusercontent.com/79740955/154965920-533a4de5-0b61-4930-b850-a8e1e8317fbd.png)
