### PR TITLE
Update to about and help dialogs

### DIFF
--- a/geosys/ui/about/about_dialog.py
+++ b/geosys/ui/about/about_dialog.py
@@ -4,7 +4,7 @@
 # This import is to enable SIP API V2
 # noinspection PyUnresolvedReferences
 import qgis  # NOQA pylint: disable=unused-import
-from qgis.PyQt import QtGui, QtWidgets
+from qgis.PyQt import QtGui, QtWidgets, QtWebKitWidgets
 from qgis.PyQt.QtCore import Qt
 
 from geosys.utilities.about import get_about_html
@@ -38,4 +38,15 @@ class AboutDialog(QtWidgets.QDialog, FORM_CLASS):
         icon = resources_path('img', 'icons', 'icon.png')
         self.setWindowIcon(QtGui.QIcon(icon))
 
+        # Make the html links open on the default browser instead
+        # of opening the current about dialog.
+        self.about_web_view.page().setLinkDelegationPolicy(
+            QtWebKitWidgets.QWebPage.DelegateAllLinks
+        )
+        self.about_web_view.linkClicked.connect(self.link_clicked)
+
         self.about_web_view.setHtml(get_about_html(message))
+
+
+    def link_clicked(self, url):
+        QtGui.QDesktopServices.openUrl(url)

--- a/geosys/ui/help/help_dialog.py
+++ b/geosys/ui/help/help_dialog.py
@@ -4,7 +4,7 @@
 # This import is to enable SIP API V2
 # noinspection PyUnresolvedReferences
 import qgis  # NOQA pylint: disable=unused-import
-from qgis.PyQt import QtGui, QtWidgets
+from qgis.PyQt import QtGui, QtWidgets, QtWebKitWidgets
 from qgis.PyQt.QtCore import Qt
 
 from geosys.utilities.help import get_help_html
@@ -39,4 +39,14 @@ class HelpDialog(QtWidgets.QDialog, FORM_CLASS):
         icon = resources_path('img', 'icons', 'icon.png')
         self.setWindowIcon(QtGui.QIcon(icon))
 
+        # Make the html links open on the default browser instead
+        # of opening the current help dialog.
+        self.help_web_view.page().setLinkDelegationPolicy(
+            QtWebKitWidgets.QWebPage.DelegateAllLinks
+        )
+        self.help_web_view.linkClicked.connect(self.link_clicked)
+
         self.help_web_view.setHtml(get_help_html(message))
+
+    def link_clicked(self, url):
+        QtGui.QDesktopServices.openUrl(url)

--- a/geosys/ui/templates/about_dialog_base.ui
+++ b/geosys/ui/templates/about_dialog_base.ui
@@ -31,16 +31,24 @@
     </widget>
    </item>
    <item row="0" column="0">
-    <widget class="MessageViewer" name="about_web_view" native="true"/>
+    <widget class="QWebView" name="about_web_view">
+     <property name="styleSheet">
+      <string notr="true">background:transparent;</string>
+     </property>
+     <property name="url">
+      <url>
+       <string>about:blank</string>
+      </url>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>
  <customwidgets>
   <customwidget>
-   <class>MessageViewer</class>
+   <class>QWebView</class>
    <extends>QWidget</extends>
-   <header>geosys.ui.widgets.message_viewer</header>
-   <container>1</container>
+   <header location="global">QtWebKitWidgets/QWebView</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/geosys/ui/templates/help_dialog_base.ui
+++ b/geosys/ui/templates/help_dialog_base.ui
@@ -25,16 +25,24 @@
     </widget>
    </item>
    <item row="0" column="0">
-    <widget class="MessageViewer" name="help_web_view" native="true"/>
+    <widget class="QWebView" name="help_web_view">
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
+     <property name="url">
+      <url>
+       <string>about:blank</string>
+      </url>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>
  <customwidgets>
   <customwidget>
-   <class>MessageViewer</class>
+   <class>QWebView</class>
    <extends>QWidget</extends>
-   <header>geosys.ui.widgets.message_viewer</header>
-   <container>1</container>
+   <header location="global">QtWebKitWidgets/QWebView</header>
   </customwidget>
  </customwidgets>
  <resources/>


### PR DESCRIPTION
Links that are in about and help dialogs now will be opened using the default browser, instead of showing the corresponding pages inside the dialog.