### PR TITLE
Fixed url filtering character issue

### DIFF
--- a/geosys/ui/widgets/geosys_coverage_downloader.py
+++ b/geosys/ui/widgets/geosys_coverage_downloader.py
@@ -471,9 +471,17 @@ def download_field_map(
     map_extension = output_map_format['extension']
     try:
         url = field_map_json['_links'][output_map_format['api_key']]
-        url = '{}?zoning=true&zoneCount={}'.format(
-            url, data.get('zoneCount')) \
-            if data.get('zoning') else url
+
+        char_question_mark = '?'  # Filtering char
+        if char_question_mark in url:  # Filtering, which starts with '?' has already been added, so appending with '&'
+            url = '{}&zoning=true&zoneCount={}'.format(
+                url, data.get('zoneCount')) \
+                if data.get('zoning') else url
+        else:  # No filtering added yet, so appending with '?'
+            url = '{}?zoning=true&zoneCount={}'.format(
+                url, data.get('zoneCount')) \
+                if data.get('zoning') else url
+
     except KeyError:
         # requested map format not found
         message = (
@@ -495,9 +503,17 @@ def download_field_map(
                 # the PNG file.
                 for item in [PGW, LEGEND]:
                     url = field_map_json['_links'][item['api_key']]
-                    url = '{}?zoning=true&zoneCount={}'.format(
-                        url, data.get('zoneCount')) \
-                        if data.get('zoning') else url
+
+                    char_question_mark = '?'  # Filtering char
+                    if char_question_mark in url:  # Filtering, which starts with '?' has already been added, so appending with '&'
+                        url = '{}&zoning=true&zoneCount={}'.format(
+                            url, data.get('zoneCount')) \
+                            if data.get('zoning') else url
+                    else:  # No filtering added yet, so appending with '?'
+                        url = '{}?zoning=true&zoneCount={}'.format(
+                            url, data.get('zoneCount')) \
+                            if data.get('zoning') else url
+
                     destination_filename = '{}{}'.format(
                         destination_base_path, item['extension'])
                     fetch_data(url, destination_filename, headers=headers)

--- a/geosys/utilities/downloader.py
+++ b/geosys/utilities/downloader.py
@@ -36,15 +36,6 @@ def fetch_data(url, output_path, headers=None, progress_dialog=None):
     :raises: ImportDialogError - when network error occurred
     """
 
-    # This is a TEMPORARY fix for a URL provided by a response from the API, which includes two filter characters (?).
-    # This fix checks if there are two filter characters and then replaces the second ? with &, which resolves the problem.
-    char_question_mark = '?'
-    list_indices = [i for i, ltr in enumerate(url) if ltr == char_question_mark]
-    if len(list_indices) > 1:
-        index = list_indices[1]
-        url = "%s%s%s" % (url[:index], '&', url[index + 1:])
-    # The TEMPORARY added fix ends here
-
     LOGGER.debug('Downloading file from URL: %s' % url)
     LOGGER.debug('Downloading to: %s' % output_path)
 


### PR DESCRIPTION
Fixes the double '?' for filtering in the create map URL. The code will now check if the API response already contains a filter, and if it does, makes use of '&' to append to the filtering; other '?' for the start of filtering in the URL.

![image](https://user-images.githubusercontent.com/79740955/155120767-0a1c43fc-999e-4e8b-8d84-39d44952438e.png)
