### PR TITLE
Map format section has been moved

### DIFF
--- a/geosys/ui/templates/geosys_dockwidget_base.ui
+++ b/geosys/ui/templates/geosys_dockwidget_base.ui
@@ -612,7 +612,7 @@
           </layout>
          </widget>
         </item>
-        <item row="3" column="0">
+        <item row="1" column="0">
          <widget class="QGroupBox" name="map_format_group">
           <property name="title">
            <string>Map Format</string>


### PR DESCRIPTION
Fixes #169 
The map format section has been moved to below the parameters section, and are now followed by the hotspots section.

![image](https://user-images.githubusercontent.com/79740955/155285973-a1185d55-732d-45f4-b577-4689fe71e021.png)
