### PR TITLE
Added filter for ELEVATION

### DIFF
--- a/geosys/ui/widgets/geosys_coverage_downloader.py
+++ b/geosys/ui/widgets/geosys_coverage_downloader.py
@@ -96,6 +96,10 @@ class CoverageSearchThread(QThread):
             self.sensor_type and self.filters.update({
                 IMAGE_SENSOR: self.sensor_type
             })
+        else:  # If elevation product is selected
+            self.filters.update({
+                MAPS_TYPE: self.map_product
+            })
 
         self.settings = QSettings()
 


### PR DESCRIPTION
No filter has been added for the elevation map type. This is no longer the case. The result will therefore not include ndvi or other map types, BUT the result from the api resquest is empty (e.g. no coverage).

![image](https://user-images.githubusercontent.com/79740955/156590350-c30ec4d6-4e0e-4930-96e4-162a2fab9b18.png)
