### PR TITLE
Fixed colorcomposition legend issue

### DIFF
--- a/geosys/ui/widgets/geosys_coverage_downloader.py
+++ b/geosys/ui/widgets/geosys_coverage_downloader.py
@@ -9,7 +9,7 @@ from PyQt5.QtCore import QThread, pyqtSignal, QByteArray, QSettings, QDate
 
 from geosys.bridge_api.default import (
     MAPS_TYPE, IMAGE_SENSOR, IMAGE_DATE, ZIPPED_FORMAT, PNG, PGW, LEGEND, SHP_EXT)
-from geosys.bridge_api.definitions import SAMZ, ELEVATION
+from geosys.bridge_api.definitions import SAMZ, ELEVATION, COLOR_COMPOSITION
 from geosys.bridge_api_wrapper import BridgeAPI
 from geosys.utilities.downloader import fetch_data, extract_zip
 from geosys.utilities.qgis_settings import QGISSettings
@@ -502,7 +502,15 @@ def download_field_map(
             if output_map_format == PNG:
                 # Download associated legend and world-file for geo-referencing
                 # the PNG file.
-                for item in [PGW, LEGEND]:
+                
+                # This step check if the map type is color composition
+                # If that is the case, legend will not be included to the items
+                # list as the API does not include a legend for color composition
+                if map_type_key == COLOR_COMPOSITION['key']:
+                    list_items = [PGW]
+                else:
+                    list_items = [PGW, LEGEND]
+                for item in list_items:
                     url = field_map_json['_links'][item['api_key']]
 
                     char_question_mark = '?'  # Filtering char


### PR DESCRIPTION
The API response does not include a legend for when the color composition map type is selected. This resulted in an error as the plugin attempted to retrieve the legend. This has now been resolved.

Here is the response from the API for color composition. There are no legend item included.

![image](https://user-images.githubusercontent.com/79740955/157000143-4c204632-4d07-4025-add0-8359920944ee.png)
