### PR TITLE
Soil map

### DIFF
--- a/geosys/bridge_api/definitions.py
+++ b/geosys/bridge_api/definitions.py
@@ -297,8 +297,8 @@ SLOPE = {
 
 # Soil map
 SOIL = {
-    'key': 'SOIL',
-    'name': 'SOIL',
+    'key': 'SOILMAP',
+    'name': 'SOILMAP',
     'map_family': samplemap,
     'description': 'Provides the in-season Soil type map. Can be generate only in the USA, contains information about soil as collected by the National Cooperative Soil Survey.'
 }

--- a/geosys/bridge_api/definitions.py
+++ b/geosys/bridge_api/definitions.py
@@ -297,8 +297,8 @@ SLOPE = {
 
 # Soil map
 SOIL = {
-    'key': 'SOILMAP',
-    'name': 'SOILMAP',
+    'key': 'soilmap',
+    'name': 'soilmap',
     'map_family': samplemap,
     'description': 'Provides the in-season Soil type map. Can be generate only in the USA, contains information about soil as collected by the National Cooperative Soil Survey.'
 }

--- a/geosys/ui/widgets/geosys_dockwidget.py
+++ b/geosys/ui/widgets/geosys_dockwidget.py
@@ -792,9 +792,9 @@ class GeosysPluginDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         else:
             self.coverage_result_list.setCurrentRow(0)
 
-            # When user selected Elevation map, we want to skip the coverage
+            # When user selected Elevation/Soil map, we want to skip the coverage
             # results panel and go straight to the map creation panel rather.
-            if self.map_product == ELEVATION['key']:
+            if self.map_product == ELEVATION['key'] or self.map_product == SOIL['key']:
                 self.show_next_page()
 
     def show_coverage_result(self, coverage_map_json, thumbnail_ba):


### PR DESCRIPTION
Fixes #170 
If the user selected SOILMAP, then the coverage results section will be skipped. Also updated the soilmap definition to be SOILMAP. Still not receiving any soil map coverage, but this seems to be the case in postman as well.
{
"coverageType": "CLEAR",
"image": {
"id": "IKc73hpUQ6t2wnh88Qfv5qX9QTLKbpUAQ3I7TUSYRYC",
"availableBands": [
"Nir",
"Red",
"Blue",
"Green"
],
"sensor": "SENTINEL_2",
"soilMaterial": "BARE",
"spatialResolution": 10.0,
"weather": "COLD",
"zenithAngleInDegree": 2.576166,
"date": "2021-11-30"
},
"maps": [
{
"type": "INSEASON_NDVI"
},
{
"type": "INSEASONFIELD_AVERAGE_REVERSE_NDVI"
},
{
"type": "INSEASONFIELD_AVERAGE_NDVI"
},
{
"type": "INSEASON_CVI"
},
{
"type": "INSEASON_CVIN"
},
{
"type": "INSEASON_EVI"
},
{
"type": "INSEASON_GNDVI"
},
{
"type": "COLORCOMPOSITION"
},
{
"type": "OM"
},
{
"type": "YGM"
},
{
"type": "YPM"
},
{
"type": "SAMZ"
}
],
"seasonField": {
"id": "x3yrreq",
"customerExternalId": "VBdolY4zptSNVmZJ/j/PV1nl4taynOE+SU+RI2rRCMQ="
}
}