### PR TITLE
Fix for duplicate sensors on docking panel

### DIFF
--- a/geosys/ui/widgets/geosys_dockwidget.py
+++ b/geosys/ui/widgets/geosys_dockwidget.py
@@ -154,6 +154,7 @@ class GeosysPluginDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         self.populate_map_products()
 
         # Populate sensor combo box
+        self.clear_combo_box(self.sensor_combo_box)
         self.populate_sensors()
 
         # Set default date value


### PR DESCRIPTION
Fixes #192 
A bug has been fixed where the sensor list on the docking panel shows duplicates for each sensor.

Below image shows no more duplicates.
![image](https://user-images.githubusercontent.com/79740955/157857829-137dd9e7-808a-45ce-91c0-e44a2c258dc0.png)
