### PR TITLE
Catalog-imagery API. S2rep, reflectance, soilmap and nitrogen maps

### DIFF
--- a/geosys/bridge_api/definitions.py
+++ b/geosys/bridge_api/definitions.py
@@ -297,8 +297,8 @@ SLOPE = {
 
 # Soil map
 SOIL = {
-    'key': 'SOIL',
-    'name': 'SOIL',
+    'key': 'soilmap',
+    'name': 'SOILMAP',
     'map_family': samplemap,
     'description': 'Provides the in-season Soil type map. Can be generate only in the USA, contains information about soil as collected by the National Cooperative Soil Survey.'
 }
@@ -334,6 +334,13 @@ BASIC_INSEASON_MAP_PRODUCTS = [
     INSEASON_GNDVI,
     INSEASON_LAI,
     INSEASON_S2REP
+]
+
+INSEASON_NITROGEN = [
+    INSEASONFIELD_AVERAGE_NDVI,
+    INSEASONFIELD_AVERAGE_LAI,
+    INSEASONFIELD_AVERAGE_REVERSE_NDVI,
+    INSEASONFIELD_AVERAGE_REVERSE_LAI
 ]
 
 INSEASON_MAP_PRODUCTS = BASIC_INSEASON_MAP_PRODUCTS + [


### PR DESCRIPTION
Fixes #171 
Fixes #174 
Fixes #177 
Fixes #170 
The catalog-imagery API has been added to the plugin, as its required to perform coverage checks and map creation for the s2rep, reflectance, soilmap and nitrogen maps. Updates to the code has also been made to accomodate those maps using the catalog-imagery API.

Inseasonfield average ndvi. Nitrogen map example
![image](https://user-images.githubusercontent.com/79740955/158674105-e411483f-04c8-4594-8259-e84af57cd83d.png)

Soil map. Only one class for this example
![image](https://user-images.githubusercontent.com/79740955/158674327-0414dc4c-8940-4003-97c9-13291020c5f4.png)

Reflectance map example
![image](https://user-images.githubusercontent.com/79740955/158674501-942f993c-7170-4b18-a364-a72f77ce4d1f.png)

S2rep example. Only EU
![image](https://user-images.githubusercontent.com/79740955/158674960-7e464c47-5d4f-4761-8dd3-81e081a37cbc.png)

