### PR TITLE
CVIN map type now makes use of the catalog-imagery API.

### DIFF
--- a/geosys/bridge_api_wrapper.py
+++ b/geosys/bridge_api_wrapper.py
@@ -378,7 +378,7 @@ class BridgeAPI(ApiClient):
         difference_map_definition = map_type_definition['difference_map']
 
         return self._get_field_map(
-            difference_map_definition['key'], request_data, 0, params)
+            difference_map_definition['key'], request_data, params=params)
 
     def get_samz_map(self, season_field_id, list_of_image_date=None, **kwargs):
         """Get requested SAMZ map.
@@ -411,4 +411,4 @@ class BridgeAPI(ApiClient):
         # Get request parameters
         params = kwargs.get('params')
 
-        return self._get_field_map(SAMZ['key'], request_data, 0, params)
+        return self._get_field_map(SAMZ['key'], request_data, params=params)

--- a/geosys/bridge_api_wrapper.py
+++ b/geosys/bridge_api_wrapper.py
@@ -378,7 +378,7 @@ class BridgeAPI(ApiClient):
         difference_map_definition = map_type_definition['difference_map']
 
         return self._get_field_map(
-            difference_map_definition['key'], request_data, params)
+            difference_map_definition['key'], request_data, 0, params)
 
     def get_samz_map(self, season_field_id, list_of_image_date=None, **kwargs):
         """Get requested SAMZ map.
@@ -411,4 +411,4 @@ class BridgeAPI(ApiClient):
         # Get request parameters
         params = kwargs.get('params')
 
-        return self._get_field_map(SAMZ['key'], request_data, params)
+        return self._get_field_map(SAMZ['key'], request_data, 0, params)

--- a/geosys/test/test_bridge_api_wrapper.py
+++ b/geosys/test/test_bridge_api_wrapper.py
@@ -42,8 +42,8 @@ class BridgeAPIWrapperTest(unittest.TestCase):
         expected_crops = [
             'SUGARCANE', 'CORN', 'MILLET', 'GRAPES', 'OTHERS', 'COTTON',
             'SUNFLOWER', 'PEANUT', 'SOYBEANS', 'ORANGE', 'RICE', 'SORGHUM',
-            'WHEAT_WINTER_DURUM', 'WHEAT_WINTER_SOFT', 'WHEAT_SPRING_DURUM',
-            'WHEAT_SPRING_SOFT', 'TRITICALE', 'BARLEY_WINTER', 'BARLEY_SPRING',
+            'WINTER_DURUM_WHEAT', 'WINTER_SOFT_WHEAT', 'SPRING_DURUM_WHEAT',
+            'SOFT_WHITE_SPRING_WHEAT', 'TRITICALE', 'WINTER_BARLEY', 'SPRING_BERALY', 'WINTER_OSR'
         ]
         self.assertEqual(sorted(crops), sorted(expected_crops))
 

--- a/geosys/test/test_bridge_api_wrapper.py
+++ b/geosys/test/test_bridge_api_wrapper.py
@@ -43,7 +43,7 @@ class BridgeAPIWrapperTest(unittest.TestCase):
             'SUGARCANE', 'CORN', 'MILLET', 'GRAPES', 'OTHERS', 'COTTON',
             'SUNFLOWER', 'PEANUT', 'SOYBEANS', 'ORANGE', 'RICE', 'SORGHUM',
             'WINTER_DURUM_WHEAT', 'WINTER_SOFT_WHEAT', 'SPRING_DURUM_WHEAT',
-            'SOFT_WHITE_SPRING_WHEAT', 'TRITICALE', 'WINTER_BARLEY', 'SPRING_BERALY', 'WINTER_OSR'
+            'SOFT_WHITE_SPRING_WHEAT', 'TRITICALE', 'WINTER_BARLEY', 'SPRING_BARLEY', 'WINTER_OSR'
         ]
         self.assertEqual(sorted(crops), sorted(expected_crops))
 

--- a/geosys/test/test_bridge_api_wrapper.py
+++ b/geosys/test/test_bridge_api_wrapper.py
@@ -95,7 +95,7 @@ class BridgeAPIWrapperTest(unittest.TestCase):
             client_secret='mapproduct_api.secret',
             use_testing_service=True)
         field_map = bridge_api.get_field_map(
-            map_type_key, season_field_id, image_date, '', 0,
+            map_type_key, season_field_id, image_date,
             # map creation parameters
             NPlanned=48,
             NMin=20,

--- a/geosys/test/test_bridge_api_wrapper.py
+++ b/geosys/test/test_bridge_api_wrapper.py
@@ -95,7 +95,7 @@ class BridgeAPIWrapperTest(unittest.TestCase):
             client_secret='mapproduct_api.secret',
             use_testing_service=True)
         field_map = bridge_api.get_field_map(
-            map_type_key, season_field_id, image_date,
+            map_type_key, season_field_id, image_date, '', 0,
             # map creation parameters
             NPlanned=48,
             NMin=20,

--- a/geosys/ui/widgets/geosys_coverage_downloader.py
+++ b/geosys/ui/widgets/geosys_coverage_downloader.py
@@ -19,7 +19,8 @@ from geosys.bridge_api.definitions import (SAMZ,
                                            INSEASONFIELD_AVERAGE_NDVI,
                                            INSEASONFIELD_AVERAGE_LAI,
                                            INSEASONFIELD_AVERAGE_REVERSE_NDVI,
-                                           INSEASONFIELD_AVERAGE_REVERSE_LAI)
+                                           INSEASONFIELD_AVERAGE_REVERSE_LAI,
+                                           INSEASON_CVIN)
 from geosys.bridge_api_wrapper import BridgeAPI
 from geosys.utilities.downloader import fetch_data, extract_zip
 from geosys.utilities.qgis_settings import QGISSettings
@@ -42,6 +43,10 @@ NITROGEN_THUMBNAIL_URL = (
 S2REP_THUMBNAIL_URL = (
     '{bridge_url}/field-level-maps/v4/season-fields/{id}/coverage/{image}'
     '/base-reference-map/INSEASON_S2REP/thumbnail.png')
+CVIN_THUMBNAIL_URL = (
+    '{bridge_url}/field-level-maps/v4/season-fields/{id}/coverage/{image}'
+    '/base-reference-map/INSEASON_CVIN/thumbnail.png')
+
 
 
 class CoverageSearchThread(QThread):
@@ -156,7 +161,7 @@ class CoverageSearchThread(QThread):
             collected_results = []
             for geometry in self.geometries:
                 # Determines the approach required to do the coverage check
-                if self.map_product == INSEASON_S2REP['key'] or self.map_product == REFLECTANCE['key']:
+                if self.map_product == INSEASON_S2REP['key'] or self.map_product == REFLECTANCE['key'] or INSEASON_CVIN['key']:
                     # Makes use of the 'catalog-imagery' API calls
                     results = searcher_client.get_catalog_imagery(
                         geometry, self.crop_type, self.sowing_date,
@@ -204,6 +209,13 @@ class CoverageSearchThread(QThread):
                                     bridge_url=searcher_client.bridge_server,
                                     id=result['seasonField']['id'],
                                     date=result['image']['date']
+                                ))
+                    elif self.map_product == INSEASON_CVIN['key']:
+                        thumbnail_url = (
+                                CVIN_THUMBNAIL_URL.format(
+                                    bridge_url=searcher_client.bridge_server,
+                                    id=result['seasonField']['id'],
+                                    image=result['image']['id']
                                 ))
                     elif self.map_product == INSEASON_S2REP['key']:
                         thumbnail_url = (


### PR DESCRIPTION
Fixes #196 
Fixes #176 
The CVIN map type now makes use of the catalog-imagery API. Thumpnails works as it should, and map creation as well. This works for both the EU and US platforms.

Created CVIN map:
![image](https://user-images.githubusercontent.com/79740955/158991571-105cc4e5-4eab-48e3-9371-3710ac6fc18b.png)

Coverage results using catalog-iamgery with thumpnails:
![image](https://user-images.githubusercontent.com/79740955/158991651-8e282d7d-601e-4004-93e9-859b68f9f924.png)

