### PR TITLE
Thumpnail fixes for nitrogen maps and S2rep maps

### DIFF
--- a/geosys/ui/widgets/geosys_coverage_downloader.py
+++ b/geosys/ui/widgets/geosys_coverage_downloader.py
@@ -37,11 +37,12 @@ NDVI_THUMBNAIL_URL = (
     '{bridge_url}/field-level-maps/v4/season-fields/{id}/coverage/{date}'
     '/base-reference-map/INSEASON_NDVI/thumbnail.png')
 NITROGEN_THUMBNAIL_URL = (
-    '{bridge_url}/field-level-maps/v4/season-fields/{id}/catalog-imagery/{date}'
+    '{bridge_url}/field-level-maps/v4/season-fields/{id}/coverage/{image}'
     '/model-map/{nitrogen_map_type}/thumbnail.png')
 S2REP_THUMBNAIL_URL = (
-    '{bridge_url}/field-level-maps/v4/season-fields/{id}/catalog-imagery/{date}'
+    '{bridge_url}/field-level-maps/v4/season-fields/{id}/coverage/{image}'
     '/base-reference-map/INSEASON_S2REP/thumbnail.png')
+
 
 class CoverageSearchThread(QThread):
     """Thread object wrapper for coverage search."""
@@ -209,7 +210,7 @@ class CoverageSearchThread(QThread):
                             S2REP_THUMBNAIL_URL.format(
                                 bridge_url=searcher_client.bridge_server,
                                 id=result['seasonField']['id'],
-                                date=result['image']['date']
+                                image=result['image']['id']
                             ))
                     elif self.map_product == INSEASONFIELD_AVERAGE_NDVI['key'] or self.map_product == INSEASONFIELD_AVERAGE_LAI['key'] or self.map_product == INSEASONFIELD_AVERAGE_REVERSE_NDVI['key'] or self.map_product == INSEASONFIELD_AVERAGE_REVERSE_LAI['key']:
                         # Nitrogen map type
@@ -219,7 +220,7 @@ class CoverageSearchThread(QThread):
                                 NITROGEN_THUMBNAIL_URL.format(
                                     bridge_url=searcher_client.bridge_server,
                                     id=result['seasonField']['id'],
-                                    date=result['image']['date'],
+                                    image=result['image']['id'],
                                     nitrogen_map_type=INSEASONFIELD_AVERAGE_NDVI['key']
                                 ))
                         elif self.map_product == INSEASONFIELD_AVERAGE_LAI['key']:
@@ -228,7 +229,7 @@ class CoverageSearchThread(QThread):
                                 NITROGEN_THUMBNAIL_URL.format(
                                     bridge_url=searcher_client.bridge_server,
                                     id=result['seasonField']['id'],
-                                    date=result['image']['date'],
+                                    image=result['image']['id'],
                                     nitrogen_map_type=INSEASONFIELD_AVERAGE_LAI['key']
                                 ))
                         elif self.map_product == INSEASONFIELD_AVERAGE_REVERSE_NDVI['key']:
@@ -237,7 +238,7 @@ class CoverageSearchThread(QThread):
                                 NITROGEN_THUMBNAIL_URL.format(
                                     bridge_url=searcher_client.bridge_server,
                                     id=result['seasonField']['id'],
-                                    date=result['image']['date'],
+                                    image=result['image']['id'],
                                     nitrogen_map_type=INSEASONFIELD_AVERAGE_REVERSE_NDVI['key']
                                 ))
                         elif self.map_product == INSEASONFIELD_AVERAGE_REVERSE_LAI['key']:
@@ -246,7 +247,7 @@ class CoverageSearchThread(QThread):
                                 NITROGEN_THUMBNAIL_URL.format(
                                     bridge_url=searcher_client.bridge_server,
                                     id=result['seasonField']['id'],
-                                    date=result['image']['date'],
+                                    image=result['image']['id'],
                                     nitrogen_map_type=INSEASONFIELD_AVERAGE_REVERSE_LAI['key']
                                 ))
                     else:  # All other map types

--- a/geosys/ui/widgets/geosys_coverage_downloader.py
+++ b/geosys/ui/widgets/geosys_coverage_downloader.py
@@ -38,7 +38,7 @@ NDVI_THUMBNAIL_URL = (
     '/base-reference-map/INSEASON_NDVI/thumbnail.png')
 NITROGEN_THUMBNAIL_URL = (
     '{bridge_url}/field-level-maps/v4/season-fields/{id}/coverage/{image}'
-    '/model-map/{nitrogen_map_type}/thumbnail.png')
+    '/model-map/{nitrogen_map_type}/n-planned/{n_value}/thumbnail.png')
 S2REP_THUMBNAIL_URL = (
     '{bridge_url}/field-level-maps/v4/season-fields/{id}/coverage/{image}'
     '/base-reference-map/INSEASON_S2REP/thumbnail.png')
@@ -213,6 +213,7 @@ class CoverageSearchThread(QThread):
                                 image=result['image']['id']
                             ))
                     elif self.map_product == INSEASONFIELD_AVERAGE_NDVI['key'] or self.map_product == INSEASONFIELD_AVERAGE_LAI['key'] or self.map_product == INSEASONFIELD_AVERAGE_REVERSE_NDVI['key'] or self.map_product == INSEASONFIELD_AVERAGE_REVERSE_LAI['key']:
+                        n_planned_value = 30
                         # Nitrogen map type
                         if self.map_product == INSEASONFIELD_AVERAGE_NDVI['key']:
                             # INSEASON AVERAGE NDVI
@@ -221,7 +222,8 @@ class CoverageSearchThread(QThread):
                                     bridge_url=searcher_client.bridge_server,
                                     id=result['seasonField']['id'],
                                     image=result['image']['id'],
-                                    nitrogen_map_type=INSEASONFIELD_AVERAGE_NDVI['key']
+                                    nitrogen_map_type=INSEASONFIELD_AVERAGE_NDVI['key'],
+                                    n_value=str(n_planned_value)
                                 ))
                         elif self.map_product == INSEASONFIELD_AVERAGE_LAI['key']:
                             # INSEASON AVERAGE LAI
@@ -230,7 +232,8 @@ class CoverageSearchThread(QThread):
                                     bridge_url=searcher_client.bridge_server,
                                     id=result['seasonField']['id'],
                                     image=result['image']['id'],
-                                    nitrogen_map_type=INSEASONFIELD_AVERAGE_LAI['key']
+                                    nitrogen_map_type=INSEASONFIELD_AVERAGE_LAI['key'],
+                                    n_value=str(n_planned_value)
                                 ))
                         elif self.map_product == INSEASONFIELD_AVERAGE_REVERSE_NDVI['key']:
                             # INSEASON AVERAGE REVERSE NDVI
@@ -239,7 +242,8 @@ class CoverageSearchThread(QThread):
                                     bridge_url=searcher_client.bridge_server,
                                     id=result['seasonField']['id'],
                                     image=result['image']['id'],
-                                    nitrogen_map_type=INSEASONFIELD_AVERAGE_REVERSE_NDVI['key']
+                                    nitrogen_map_type=INSEASONFIELD_AVERAGE_REVERSE_NDVI['key'],
+                                    n_value=str(n_planned_value)
                                 ))
                         elif self.map_product == INSEASONFIELD_AVERAGE_REVERSE_LAI['key']:
                             # INSEASON AVERAGE REVERSE LAI
@@ -248,7 +252,8 @@ class CoverageSearchThread(QThread):
                                     bridge_url=searcher_client.bridge_server,
                                     id=result['seasonField']['id'],
                                     image=result['image']['id'],
-                                    nitrogen_map_type=INSEASONFIELD_AVERAGE_REVERSE_LAI['key']
+                                    nitrogen_map_type=INSEASONFIELD_AVERAGE_REVERSE_LAI['key'],
+                                    n_value=str(n_planned_value)
                                 ))
                     else:  # All other map types
                         thumbnail_url = (


### PR DESCRIPTION
Fixes #197 
The thumpnails has been fixed for both nitrogen maps and s2rep maps. Nitrogen maps makes use of the a default n-planned value at the moment. Issue ticket: https://github.com/GEOSYS/qgis-plugin/issues/203

S2REP:
![image](https://user-images.githubusercontent.com/79740955/159024965-a43a42c6-0548-4301-b328-df54b86bb63f.png)

Nitrogen maps:
![image](https://user-images.githubusercontent.com/79740955/159025192-f191c27c-b3fb-471b-b268-93a145902e50.png)
