### PR TITLE
Elevation map bug fix

### DIFF
--- a/geosys/ui/widgets/geosys_dockwidget.py
+++ b/geosys/ui/widgets/geosys_dockwidget.py
@@ -338,6 +338,9 @@ class GeosysPluginDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
             elif self.map_product == SOIL['key']:
                 # Used when soilmap type. This is a workaround suggested by GeoSys
                 item_json['maps'][0]['type'] = SOIL['key']
+            elif self.map_product == ELEVATION['key']:
+                # For elevation map type
+                item_json['maps'][0]['type'] = ELEVATION['key']
 
             self.selected_coverage_results.append(item_json)
 


### PR DESCRIPTION
fixes #210 
When the elevation map type has been selected, the correct map creation will be done using the ELEVATION key.
This were a bug in the code.

![image](https://user-images.githubusercontent.com/79740955/165262350-fc37bbbc-d351-46a2-835e-bd993e4adca4.png)
