### PR TITLE
Updates to the png format

### DIFF
--- a/geosys/bridge_api/default.py
+++ b/geosys/bridge_api/default.py
@@ -88,14 +88,16 @@ OFFSET = 'offset'
 
 # file extension
 PGW_EXT = '.pgw'
-PNG_EXT = '.png'
+PNG_EXT = '.png.kmz'
+PNG_EXT_CC = '.png'  # PNG format used by color composition
 TIFF_EXT = '.tif'
 SHP_EXT = '.shp'
 KMZ_EXT = '.kmz'
 LEGEND_EXT = '.legend.png'
 
 # API key
-PNG_KEY = 'image:image/png'
+PNG_KEY = 'image:application/vnd.google-earth.kmz+png'
+PNG_KEY_CC = 'image:image/png'  # PNG format used by color composition
 ZIPPED_TIFF_KEY = 'image:image/tiff+zip'
 ZIPPED_SHP_KEY = 'image:application/shp+zip'
 KMZ_KEY = 'image:application/vnd.google-earth.kmz'
@@ -110,6 +112,10 @@ PGW = {
 PNG = {
     'api_key': PNG_KEY,
     'extension': PNG_EXT
+}
+PNG_CC = {  # Only required by color composition
+    'api_key': PNG_KEY_CC,
+    'extension': PNG_EXT_CC
 }
 ZIPPED_TIFF = {
     'api_key': ZIPPED_TIFF_KEY,
@@ -129,6 +135,6 @@ LEGEND = {
 }
 
 ZIPPED_FORMAT = [ZIPPED_TIFF, ZIPPED_SHP]
-RASTER_FORMAT = [ZIPPED_TIFF, PNG]
+RASTER_FORMAT = [ZIPPED_TIFF, PNG, PNG_CC]
 VECTOR_FORMAT = [ZIPPED_SHP, KMZ]
-VALID_QGIS_FORMAT = [ZIPPED_TIFF, ZIPPED_SHP, KMZ, PNG]
+VALID_QGIS_FORMAT = [ZIPPED_TIFF, ZIPPED_SHP, KMZ, PNG, PNG_CC]

--- a/geosys/ui/widgets/geosys_coverage_downloader.py
+++ b/geosys/ui/widgets/geosys_coverage_downloader.py
@@ -8,7 +8,7 @@ import tempfile
 from PyQt5.QtCore import QThread, pyqtSignal, QByteArray, QSettings, QDate
 
 from geosys.bridge_api.default import (
-    MAPS_TYPE, IMAGE_SENSOR, IMAGE_DATE, ZIPPED_FORMAT, PNG, PGW, LEGEND, SHP_EXT, BRIDGE_URLS)
+    MAPS_TYPE, IMAGE_SENSOR, IMAGE_DATE, ZIPPED_FORMAT, PNG, PNG_CC, PGW, LEGEND, SHP_EXT, BRIDGE_URLS)
 from geosys.bridge_api.definitions import (SAMZ,
                                            ELEVATION,
                                            COLOR_COMPOSITION,
@@ -658,7 +658,7 @@ def download_field_map(
             destination_filename = (
                     destination_base_path + output_map_format['extension'])
             fetch_data(url, destination_filename, headers=headers)
-            if output_map_format == PNG:
+            if output_map_format == PNG or output_map_format == PNG_CC:
                 # Download associated legend and world-file for geo-referencing
                 # the PNG file.
                 

--- a/geosys/ui/widgets/geosys_dockwidget.py
+++ b/geosys/ui/widgets/geosys_dockwidget.py
@@ -39,7 +39,7 @@ from qgis.core import (
 from qgis.PyQt.QtCore import Qt
 
 from geosys.bridge_api.default import (
-    VECTOR_FORMAT, PNG, ZIPPED_TIFF, ZIPPED_SHP, KMZ,
+    VECTOR_FORMAT, PNG, PNG_CC, ZIPPED_TIFF, ZIPPED_SHP, KMZ,
     VALID_QGIS_FORMAT, YIELD_AVERAGE, YIELD_MINIMUM, YIELD_MAXIMUM,
     ORGANIC_AVERAGE, POSITION, FILTER, SAMZ_ZONE, SAMZ_ZONING, HOTSPOT, ZONING_SEGMENTATION,
     MAX_FEATURE_NUMBERS, DEFAULT_ZONE_COUNT, GAIN, OFFSET, DEFAULT_N_PLANNED,
@@ -49,7 +49,8 @@ from geosys.bridge_api.definitions import (
     ARCHIVE_MAP_PRODUCTS, ALL_SENSORS, SENSORS, INSEASON_NDVI, INSEASON_EVI,
     SAMZ, SOIL, ELEVATION, REFLECTANCE, LANDSAT_8, LANDSAT_9, SENTINEL_2,
     INSEASONFIELD_AVERAGE_NDVI, INSEASONFIELD_AVERAGE_REVERSE_NDVI,
-    INSEASONFIELD_AVERAGE_LAI, INSEASONFIELD_AVERAGE_REVERSE_LAI)
+    INSEASONFIELD_AVERAGE_LAI, INSEASONFIELD_AVERAGE_REVERSE_LAI,
+    COLOR_COMPOSITION)
 from geosys.bridge_api.utilities import get_definition
 from geosys.ui.help.help_dialog import HelpDialog
 from geosys.ui.widgets.geosys_coverage_downloader import (
@@ -254,9 +255,24 @@ class GeosysPluginDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
 
                 self.kmz_radio_button.setChecked(False)
                 self.kmz_radio_button.setEnabled(False)
+            elif self.map_product == COLOR_COMPOSITION['key']:
+                # Color composition can only work with png
+                self.png_radio_button.setChecked(True)
+                self.png_radio_button.setEnabled(True)
+
+                # These formats are not available for color composition
+                self.tiff_radio_button.setChecked(False)
+                self.tiff_radio_button.setEnabled(False)
+
+                self.shp_radio_button.setChecked(False)
+                self.shp_radio_button.setEnabled(False)
+
+                self.kmz_radio_button.setChecked(False)
+                self.kmz_radio_button.setEnabled(False)
             else:
                 # If these radio buttons has been disabled, it is reenabled
                 self.png_radio_button.setEnabled(True)
+                self.tiff_radio_button.setEnabled(True)
                 self.shp_radio_button.setEnabled(True)
                 self.kmz_radio_button.setEnabled(True)
 
@@ -412,10 +428,19 @@ class GeosysPluginDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
 
     def get_map_format(self):
         """Get selected map format from the radio button."""
+
+        if self.map_product == COLOR_COMPOSITION['key']:
+            # Color composition will make use of the '.png' format
+            # No other format works with color composition
+            png = PNG_CC
+        else:
+            # All other formats will make use of the '.png.kmz' format
+            png = PNG
+
         widget_data = [
             {
                 'widget': self.png_radio_button,
-                'data': PNG
+                'data': png
             },
             {
                 'widget': self.tiff_radio_button,


### PR DESCRIPTION
fixes #214 
The png format will now make use of the png.kmz format. This has been done because png does not support coordinate system storage, png.kmz does.
Colorcomposition does not support png.kmz on the APIs side, and therefore support has been buildin to the plugin to make use of png for this map type.
Also added a step to disable tif, shp, and kmz for colorcompostion, as colorcomposition does not support these map types.

Colorcomposition uses png, other map types makes use of png.kmz
![image](https://user-images.githubusercontent.com/79740955/165753826-731a9a46-4b98-496c-b733-06c2b7c63a00.png)

Colorcompostion only works with png
![image](https://user-images.githubusercontent.com/79740955/165753735-0b673f52-a8ca-41de-8170-27498c228bf6.png)
