### PR TITLE
Landsat-9 has been added to the metadata

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -19,7 +19,7 @@ about=GEOSYS® Plugin for QGIS is the easiest way to experience field level capa
  Highlights:
  - Polygon-based maps creation capabilities
  - Multi index map option: NDVI, GNDVI, EVI, CVI, CVIN, S2REP
- - Multi sensor option : Sentinel 2, Landsat 8, Deimos, Modis, Resourcesat
+ - Multi sensor option : Sentinel 2, Landsat 8, Landsat-9, Deimos, Modis, Resourcesat
  - Visualization of Spectral maps
 
  Resources:


### PR DESCRIPTION
The list of sensors contained in the metadata.txt file for the plugin has been updated. It will now display in QGIS and on the QGIS plugin repo.

![image](https://user-images.githubusercontent.com/79740955/167118197-22525092-5d3b-4386-b649-f99c7cbdc299.png)
