### PR TITLE
Update QGIS versions to the test workflow file

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,8 @@ jobs:
         qgis_version_tag:
           - release-3_10
           - release-3_16
-          - release-3_22
+          - release-3_24
+          - release-3_26
 
     steps:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
           - release-3_10
           - release-3_16
           - release-3_24
-          - release-3_26
+          - final-3_26_0
 
     steps:
 


### PR DESCRIPTION
QGIS 3.22 removed, QGIS 3.24 and 3.26 added.