### PR TITLE
Update CI test images

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,6 @@ jobs:
         qgis_version_tag:
           - release-3_10
           - release-3_16
-          - release-3_24
           - final-3_26_0
 
     steps:


### PR DESCRIPTION
Remove QGIS 3.24 as it is currently failing due to unrelated plugin issue