### PR TITLE
Major updates to SAMZ, YPM and YGM

### DIFF
--- a/geosys/bridge_api/default.py
+++ b/geosys/bridge_api/default.py
@@ -59,8 +59,30 @@ DEFAULT_ZONE_COUNT = 5
 DEFAULT_GAIN = 0.0
 DEFAULT_OFFSET = 0.0
 
-# coverage filters
+# Thumbnail URLs
+NDVI_THUMBNAIL_URL = (
+    '{bridge_url}/field-level-maps/v4/season-fields/{id}/coverage/{date}'
+    '/base-reference-map/INSEASON_NDVI/thumbnail.png')
+NITROGEN_THUMBNAIL_URL = (
+    '{bridge_url}/field-level-maps/v4/season-fields/{id}/coverage/{image}'
+    '/model-map/{nitrogen_map_type}/n-planned/{n_value}/thumbnail.png')
+S2REP_THUMBNAIL_URL = (
+    '{bridge_url}/field-level-maps/v4/season-fields/{id}/coverage/{image}'
+    '/base-reference-map/INSEASON_S2REP/thumbnail.png')
+CVIN_THUMBNAIL_URL = (
+    '{bridge_url}/field-level-maps/v4/season-fields/{id}/coverage/{image}'
+    '/base-reference-map/INSEASON_CVIN/thumbnail.png')
+YGM_THUMBNAIL_URL = (
+    '{bridge_url}/field-level-maps/v4/season-fields/{id}/coverage/{image}'
+    '/yield-goal-map/YGM/historical-yield-average/80/max-yield-Goal/100/min-yield-Goal/10/thumbnail.png')
+YPM_THUMBNAIL_URL = (
+    '{bridge_url}/field-level-maps/v4/season-fields/{id}/coverage/{image}'
+    '/yield-variability-map/YPM/historical-yield-average/80/thumbnail.png')
+SAMZ_THUMBNAIL_URL = (
+    '{bridge_url}/field-level-maps/v4/season-fields/{id}/'
+    '/management-zones-map/SAMZ/thumbnail.png')
 
+# coverage filters
 COVERAGE_TYPE = 'CoverageType'
 IMAGE_DATE = 'Image.Date'
 IMAGE_SENSOR = 'Image.Sensor'
@@ -70,7 +92,6 @@ MAPS_TYPE = 'Maps.Type'
 MAP_LIMIT = '$limit'
 
 # map creation parameters
-
 YIELD_AVERAGE = 'HistoricalYieldAverage'
 YIELD_MINIMUM = 'MinYieldGoal'
 YIELD_MAXIMUM = 'MaxYieldGoal'

--- a/geosys/bridge_api/default.py
+++ b/geosys/bridge_api/default.py
@@ -34,8 +34,8 @@ IDENTITY_URLS = {
 }
 BRIDGE_URLS = {
     'na': {
-        'test': 'http://api-pp.geosys-na.net',
-        'prod': 'http://api.geosys-na.net'
+        'test': 'https://api-pp.geosys-na.net',
+        'prod': 'https://api.geosys-na.net'
     },
     'eu': {
         'test': 'https://api-pp.geosys-na.net',
@@ -51,11 +51,11 @@ MAX_FEATURE_NUMBERS = 10
 DEFAULT_N_PLANNED = 0.01
 
 # Default parameters for map creation
-DEFAULT_AVE_YIELD = 0.0
-DEFAULT_MIN_YIELD = 0.0
-DEFAULT_MAX_YIELD = 0.0
+DEFAULT_AVE_YIELD = 1.0
+DEFAULT_MIN_YIELD = 1.0
+DEFAULT_MAX_YIELD = 1.0
 DEFAULT_ORGANIC_AVE = 0.0
-DEFAULT_ZONE_COUNT = 0
+DEFAULT_ZONE_COUNT = 5
 DEFAULT_GAIN = 0.0
 DEFAULT_OFFSET = 0.0
 

--- a/geosys/bridge_api/field_level_maps.py
+++ b/geosys/bridge_api/field_level_maps.py
@@ -210,78 +210,93 @@ class FieldLevelMapsAPIClient(ApiClient):
             if (map_type['key'] == REFLECTANCE['key'] or
                     map_type['key'] == INSEASON_S2REP['key']):
                 # Reflectance and S2REP maps needs to make use of the catalog-imagery API
-                full_url = self.full_url('season-fields',
-                                         seasonfield_id,
-                                         'coverage',
-                                         image_id,
-                                         map_family['endpoint'],
-                                         map_type['key'])
+                full_url = self.full_url(
+                    'season-fields',
+                    seasonfield_id,
+                    'coverage',
+                    image_id,
+                    map_family['endpoint'],
+                    map_type['key']
+                )
 
                 response = self.get(
                     full_url,
                     headers=headers,
                     params=params,
-                    json=data)
+                    json=data
+                )
             elif map_type['key'] in nitrogen_maps:
-                full_url = self.full_url('season-fields',
-                                         seasonfield_id,
-                                         'coverage',
-                                         image_id,
-                                         map_family['endpoint'],
-                                         map_type['key'],
-                                         'n-planned',
-                                         str(n_planned))
+                full_url = self.full_url(
+                    'season-fields',
+                    seasonfield_id,
+                    'coverage',
+                    image_id,
+                    map_family['endpoint'],
+                    map_type['key'],
+                    'n-planned',
+                    str(n_planned)
+                )
 
                 response = self.get(
                     full_url,
                     headers=headers,
                     params=params,
-                    json=data)
+                    json=data
+                )
             elif map_type['key'] == YVM['key']:
-                full_url = self.full_url('season-fields',
-                                         seasonfield_id,
-                                         'coverage',
-                                         image_id,
-                                         map_family['endpoint'],
-                                         map_type['key'],
-                                         'historical-yield-average',
-                                         str(yield_val))
+                full_url = self.full_url(
+                    'season-fields',
+                    seasonfield_id,
+                    'coverage',
+                    image_id,
+                    map_family['endpoint'],
+                    map_type['key'],
+                    'historical-yield-average',
+                    str(yield_val)
+                )
 
                 response = self.get(
                     full_url,
                     headers=headers,
                     params=params,
-                    json=data)
+                    json=data
+                )
             elif map_type['key'] == YGM['key']:
-                full_url = self.full_url('season-fields',
-                                         seasonfield_id,
-                                         'coverage',
-                                         image_id,
-                                         map_family['endpoint'],
-                                         map_type['key'],
-                                         'historical-yield-average',
-                                         str(yield_val),
-                                         'max-yield-Goal',
-                                         str(max_yield_val),
-                                         'min-yield-Goal',
-                                         str(min_yield_val))
+                full_url = self.full_url(
+                    'season-fields',
+                    seasonfield_id,
+                    'coverage',
+                    image_id,
+                    map_family['endpoint'],
+                    map_type['key'],
+                    'historical-yield-average',
+                    str(yield_val),
+                    'max-yield-Goal',
+                    str(max_yield_val),
+                    'min-yield-Goal',
+                    str(min_yield_val)
+                )
 
                 response = self.get(
                     full_url,
                     headers=headers,
                     params=params,
-                    json=data)
+                    json=data
+                )
             elif map_type['key'] == SAMZ['key']:
-                full_url = self.full_url('season-fields',
-                                         seasonfield_id,
-                                         'management-zones-map',
-                                         'SAMZ')
+                full_url = self.full_url(
+                    'season-fields',
+                    seasonfield_id,
+                    'management-zones-map',
+                    'SAMZ'
+                )
 
                 response = self.get(
                     full_url,
                     headers=headers,
                     params=params,
-                    json=data)
+                    json=data
+                )
             elif map_type['key'] == SOIL['key']:
                 # Body required by soilmap
                 # This is a workaround provided by GeoSys
@@ -302,7 +317,8 @@ class FieldLevelMapsAPIClient(ApiClient):
                     full_url,
                     headers=headers,
                     params=params,
-                    json=data)
+                    json=data
+                )
             else:
                 full_url = self.full_url(
                     'maps',
@@ -314,7 +330,8 @@ class FieldLevelMapsAPIClient(ApiClient):
                      full_url,
                      headers=headers,
                      params=params,
-                     json=data)
+                     json=data
+                )
 
             return response.json()
 

--- a/geosys/bridge_api/field_level_maps.py
+++ b/geosys/bridge_api/field_level_maps.py
@@ -11,7 +11,10 @@ from geosys.bridge_api.definitions import (
     INSEASONFIELD_AVERAGE_LAI,
     INSEASONFIELD_AVERAGE_REVERSE_NDVI,
     INSEASONFIELD_AVERAGE_REVERSE_LAI,
-    INSEASON_S2REP
+    INSEASON_S2REP,
+    SAMZ,
+    YVM,
+    YGM
 )
 from geosys.bridge_api.utilities import get_definition
 
@@ -138,7 +141,16 @@ class FieldLevelMapsAPIClient(ApiClient):
 
         return response.json()
 
-    def get_field_map(self, map_type_key, data, n_planned=1.0, params=None):
+    def get_field_map(
+            self,
+            map_type_key,
+            data,
+            n_planned=1.0,
+            yield_val=None,
+            min_yield_val=None,
+            max_yield_val=None,
+            params=None
+    ):
         """Get requested field map.
 
         :param map_type_key: Map type key.
@@ -157,6 +169,15 @@ class FieldLevelMapsAPIClient(ApiClient):
 
         :param n_planned: Value used for nitrogen maps
         :type n_planned: float
+
+        :param yield_val: Average yield
+        :type yield_val: float
+
+        :param min_yield_val: Minimum yield
+        :type min_yield_val: float
+
+        :param max_yield_val: Maximum yield
+        :type max_yield_val: float
 
         :param params: Map creation parameters.
         :type params: dict
@@ -210,6 +231,51 @@ class FieldLevelMapsAPIClient(ApiClient):
                                          map_type['key'],
                                          'n-planned',
                                          str(n_planned))
+
+                response = self.get(
+                    full_url,
+                    headers=headers,
+                    params=params,
+                    json=data)
+            elif map_type['key'] == YVM['key']:
+                full_url = self.full_url('season-fields',
+                                         seasonfield_id,
+                                         'coverage',
+                                         image_id,
+                                         map_family['endpoint'],
+                                         map_type['key'],
+                                         'historical-yield-average',
+                                         str(yield_val))
+
+                response = self.get(
+                    full_url,
+                    headers=headers,
+                    params=params,
+                    json=data)
+            elif map_type['key'] == YGM['key']:
+                full_url = self.full_url('season-fields',
+                                         seasonfield_id,
+                                         'coverage',
+                                         image_id,
+                                         map_family['endpoint'],
+                                         map_type['key'],
+                                         'historical-yield-average',
+                                         str(yield_val),
+                                         'max-yield-Goal',
+                                         str(max_yield_val),
+                                         'min-yield-Goal',
+                                         str(min_yield_val))
+
+                response = self.get(
+                    full_url,
+                    headers=headers,
+                    params=params,
+                    json=data)
+            elif map_type['key'] == SAMZ['key']:
+                full_url = self.full_url('season-fields',
+                                         seasonfield_id,
+                                         'management-zones-map',
+                                         'SAMZ')
 
                 response = self.get(
                     full_url,

--- a/geosys/bridge_api_wrapper.py
+++ b/geosys/bridge_api_wrapper.py
@@ -250,7 +250,16 @@ class BridgeAPI(ApiClient):
 
         return coverages_json
 
-    def _get_field_map(self, map_type_key, request_data, n_planned=None, params=None):
+    def _get_field_map(
+            self,
+            map_type_key,
+            request_data,
+            n_planned=None,
+            yield_val=None,
+            min_yield_val=None,
+            max_yield_val=None,
+            params=None
+    ):
         """Actual method to call field map creation request.
 
         :param map_type_key: Map type key.
@@ -272,7 +281,13 @@ class BridgeAPI(ApiClient):
         api_client = FieldLevelMapsAPIClient(
             self.access_token, self.bridge_server)
         field_map_json = api_client.get_field_map(
-            map_type_key, request_data, n_planned, params)
+            map_type_key,
+            request_data,
+            n_planned,
+            yield_val,
+            min_yield_val,
+            max_yield_val,
+            params)
 
         return field_map_json
 
@@ -291,7 +306,16 @@ class BridgeAPI(ApiClient):
         return map_json
 
     def get_field_map(
-            self, map_type_key, season_field_id, image_date, image_id=None, n_planned=1.0, **kwargs):
+            self,
+            map_type_key,
+            season_field_id,
+            image_date,
+            image_id=None,
+            n_planned=1.0,
+            yield_val=0,
+            min_yield_val=0,
+            max_yield_val=0,
+            **kwargs):
         """Get requested field map.
 
         :param map_type_key: Map type key.
@@ -308,6 +332,15 @@ class BridgeAPI(ApiClient):
 
         :param n_planned: Value used for nitrogen maps
         :type n_planned: float
+
+        :param yield_val: Average yield
+        :type yield_val: float
+
+        :param min_yield_val: Minimum yield
+        :type min_yield_val: float
+
+        :param max_yield_val: Maximum yield
+        :type max_yield_val: float
 
         :param kwargs: Other map creation and request parameters.
 
@@ -330,7 +363,14 @@ class BridgeAPI(ApiClient):
         # Get request parameters
         params = kwargs.get('params')
 
-        return self._get_field_map(map_type_key, request_data, n_planned, params)
+        return self._get_field_map(
+            map_type_key,
+            request_data,
+            n_planned,
+            yield_val,
+            min_yield_val,
+            max_yield_val,
+            params)
 
     def get_difference_map(
             self, map_type_key, season_field_id,

--- a/geosys/ui/templates/geosys_dockwidget_base.ui
+++ b/geosys/ui/templates/geosys_dockwidget_base.ui
@@ -42,7 +42,7 @@
        </sizepolicy>
       </property>
       <property name="currentIndex">
-       <number>0</number>
+       <number>2</number>
       </property>
       <widget class="QWidget" name="coverage_form_page">
        <property name="minimumSize">
@@ -321,6 +321,9 @@
                <height>0</height>
               </size>
              </property>
+             <property name="minimum">
+              <double>1.000000000000000</double>
+             </property>
              <property name="maximum">
               <double>999.990000000000009</double>
              </property>
@@ -353,6 +356,9 @@
                <height>0</height>
               </size>
              </property>
+             <property name="minimum">
+              <double>1.000000000000000</double>
+             </property>
              <property name="maximum">
               <double>999.990000000000009</double>
              </property>
@@ -378,6 +384,9 @@
                <width>302</width>
                <height>0</height>
               </size>
+             </property>
+             <property name="minimum">
+              <double>1.000000000000000</double>
              </property>
              <property name="maximum">
               <double>999.990000000000009</double>
@@ -430,6 +439,12 @@
                <width>302</width>
                <height>0</height>
               </size>
+             </property>
+             <property name="minimum">
+              <number>2</number>
+             </property>
+             <property name="value">
+              <number>5</number>
              </property>
             </widget>
            </item>

--- a/geosys/ui/widgets/geosys_coverage_downloader.py
+++ b/geosys/ui/widgets/geosys_coverage_downloader.py
@@ -17,7 +17,14 @@ from geosys.bridge_api.default import (
     PGW,
     LEGEND,
     SHP_EXT,
-    BRIDGE_URLS
+    BRIDGE_URLS,
+    NDVI_THUMBNAIL_URL,
+    NITROGEN_THUMBNAIL_URL,
+    S2REP_THUMBNAIL_URL,
+    CVIN_THUMBNAIL_URL,
+    YGM_THUMBNAIL_URL,
+    YPM_THUMBNAIL_URL,
+    SAMZ_THUMBNAIL_URL
 )
 from geosys.bridge_api.definitions import (
     SAMZ,
@@ -48,27 +55,6 @@ __email__ = "rohmat@kartoza.com"
 __revision__ = "$Format:%H$"
 
 settings = QSettings()
-NDVI_THUMBNAIL_URL = (
-    '{bridge_url}/field-level-maps/v4/season-fields/{id}/coverage/{date}'
-    '/base-reference-map/INSEASON_NDVI/thumbnail.png')
-NITROGEN_THUMBNAIL_URL = (
-    '{bridge_url}/field-level-maps/v4/season-fields/{id}/coverage/{image}'
-    '/model-map/{nitrogen_map_type}/n-planned/{n_value}/thumbnail.png')
-S2REP_THUMBNAIL_URL = (
-    '{bridge_url}/field-level-maps/v4/season-fields/{id}/coverage/{image}'
-    '/base-reference-map/INSEASON_S2REP/thumbnail.png')
-CVIN_THUMBNAIL_URL = (
-    '{bridge_url}/field-level-maps/v4/season-fields/{id}/coverage/{image}'
-    '/base-reference-map/INSEASON_CVIN/thumbnail.png')
-YGM_THUMBNAIL_URL = (
-    '{bridge_url}/field-level-maps/v4/season-fields/{id}/coverage/{image}'
-    '/yield-goal-map/YGM/historical-yield-average/80/max-yield-Goal/100/min-yield-Goal/10/thumbnail.png')
-YPM_THUMBNAIL_URL = (
-    '{bridge_url}/field-level-maps/v4/season-fields/{id}/coverage/{image}'
-    '/yield-variability-map/YPM/historical-yield-average/80/thumbnail.png')
-SAMZ_THUMBNAIL_URL = (
-    '{bridge_url}/field-level-maps/v4/season-fields/{id}/'
-    '/management-zones-map/SAMZ/thumbnail.png')
 
 
 class CoverageSearchThread(QThread):

--- a/geosys/ui/widgets/geosys_dockwidget.py
+++ b/geosys/ui/widgets/geosys_dockwidget.py
@@ -776,7 +776,10 @@ class GeosysPluginDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
                 is_success, message = create_map(
                     map_specification, self.output_directory, filename,
                     data=data, output_map_format=self.output_map_format,
-                    n_planned_value=self.n_planned_value
+                    n_planned_value=self.n_planned_value,
+                    yield_val=self.yield_average_form.value(),
+                    min_yield_val=self.yield_minimum_form.value(),
+                    max_yield_val=self.yield_maximum_form.value()
                 )
                 if not is_success:
                     QMessageBox.critical(


### PR DESCRIPTION
fixes #245 
fixes #236 

SAMZ, YPM and YGM now makes use of the catalog-imagery API as the older API has been depracated.
Coverage search, thumpnail display and map creation has been updated.
The minimum average yield, minumum yield and maximum yield has been set to 1, as less will break the API.
The minimum number of zones has been set to 2, as less will break the API. The default zone count has been set to 5.
All has been tested and is in good working order.

Coverage results (SAMZ):
![image](https://user-images.githubusercontent.com/79740955/191940269-96d31d2a-8211-42c7-ae3d-7a523b501d3f.png)

Map creation (SAMZ - 5 zones):
![image](https://user-images.githubusercontent.com/79740955/191940385-3e9d3714-80ff-4f32-bd56-346b3ba9903b.png)

@LNArtus Updates has been made and the pull request has been done. Reviewing will now follow, then merging.
