### PR TITLE
Run tests on ubuntu 22.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Running tests on QGIS ${{ matrix.qgis_version_tag }}
 
     strategy:


### PR DESCRIPTION
The latest ubuntu OS contains python 3.12 which some of the tools used in the plugin testing hasn't upgraded their APIs to match the new introduced changes. 

Setting the testing workflow to use ubuntu 22.04 until there are updates in the tools to match the latest python version