### PR TITLE
Setup for test mock API server

### DIFF
--- a/geosys/bridge_api_wrapper.py
+++ b/geosys/bridge_api_wrapper.py
@@ -76,6 +76,8 @@ class BridgeAPI(ApiClient):
             client_id,
             client_secret,
             use_testing_service=False,
+            identity_url=None,
+            server_url=None,
             proxies=None):
         """Wrapper implementation for bridge api.
 
@@ -115,10 +117,11 @@ class BridgeAPI(ApiClient):
         # create server url
         self.identity_server = (IDENTITY_URLS[self.region]['test']
                                 if self.use_testing_service
-                                else IDENTITY_URLS[self.region]['prod'])
-        self.bridge_server = (BRIDGE_URLS[self.region]['test']
+                                else identity_url or IDENTITY_URLS[self.region]['prod'])
+        self.bridge_server = (server_url or BRIDGE_URLS[self.region]['test']
                               if self.use_testing_service
-                              else BRIDGE_URLS[self.region]['prod'])
+                              else server_url or BRIDGE_URLS[self.region]['prod'])
+
 
         # authenticate user
         self.authenticated, self.authentication_message = self.authenticate()

--- a/geosys/test/mock/geosys_api_server_app.py
+++ b/geosys/test/mock/geosys_api_server_app.py
@@ -1,0 +1,152 @@
+import logging
+
+from flask import Flask, request, jsonify
+app = Flask(__name__)
+
+# Configure logging
+logging.basicConfig(
+    level=logging.DEBUG,  # Set the lowest level to capture debug and above logs
+    format="%(asctime)s - %(levelname)s - %(message)s",
+    handlers=[
+        logging.StreamHandler()  # Directs logs to the terminal
+    ]
+)
+
+@app.route("/v2.1/connect/token", methods=["POST"])
+def token():
+    if (
+        request.form.get("grant_type") == "password"
+        and request.form.get("client_id") == "test"
+        and request.form.get("username") == "test"
+        and request.form.get("password") == "test"
+        and request.form.get("client_secret") == "test.secret"
+    ):
+        response = {
+            "access_token": "token",
+            "expires_in": 3600,
+            "token_type": "Bearer",
+            "scope": "offline_access openid"
+        }
+        return jsonify(response)
+    else:
+        print(f"Problem in authentication {request.form}")
+        app.logger.error(f"Problem in authentication {request.form}")
+        return jsonify({"error": "invalid_request"}), 400
+
+
+@app.route("/field-level-maps/v4/coverage", methods=["POST"])
+def field_level_maps_coverage():
+    if request.headers.get("accept") != "application/json" or \
+       request.headers.get("content-type") != "application/json":
+        return jsonify({"error": "Invalid headers"}), 400
+
+    data = request.get_json()
+    if not data or "Geometry" not in data or "Crop" not in data or "SowingDate" not in data:
+        return jsonify({"error": "Invalid data input"}), 400
+
+    response = [
+        {
+            "coverageType": "CLEAR",
+            "image": {
+                "id": "IKc73hpUQ726BpoqhQpaU8SfYGFYTAL5hhyYZq4PwFY",
+                "sensor": "SENTINEL_2",
+                "soilMaterial": "BARE",
+                "weather": "COLD",
+                "date": "2024-11-02"
+            },
+            "maps": [{}]
+        }
+    ]
+    return jsonify(response)
+
+@app.route("/field-level-maps/v4/maps/base-reference-map/<string:string_id>", methods=["POST"])
+def base_reference_map(string_id):
+    if request.headers.get("accept") != "application/json" or \
+       request.headers.get("content-type") != "application/json":
+        return jsonify({"error": "Invalid headers"}), 400
+
+    data = request.get_json()
+    if not data or "SeasonField" not in data or "Image" not in data:
+        return jsonify({"error": "Invalid data structure"}), 400
+
+    response = {
+        "id": "09BLXmtcED029BKAoVnjZKEQ",
+        "externalIds": {},
+        "seasonField": {
+            "id": "seasonfield_id",
+            "externalIds": {
+                "id": "1LYkyW0ykCTFTpLEYZrMr9",
+                "legacY_ID_NA": "nja3zv9"
+            },
+            "customerExternalId": None
+        },
+        "_links": {},
+        "index": 0,
+        "hotSpots": [],
+        "legend": {},
+        "zones": [],
+        "date": "2024-10-21"
+    }
+    return jsonify(response)
+
+@app.route("/field-level-maps/v4/maps/difference-map/<string:string_id>", methods=["POST"])
+def difference_map(string_id):
+    if request.headers.get("accept") != "application/json" or request.headers.get("content-type") != "application/json":
+        return jsonify({"error": "Invalid headers"}), 400
+
+    data = request.get_json()
+    if not data or "SeasonField" not in data or "EarliestImage" not in data or "LatestImage" not in data:
+        return jsonify({"error": "Invalid request data"}), 400
+
+    response = {
+        "id": "09BLXmtcED029BKAoVnjZKEQ",
+        "externalIds": {},
+        "seasonField": {
+            "id": "seasonfield_id",
+            "externalIds": {
+                "id": "1LYkyW0ykCTFTpLEYZrMr9",
+                "legacY_ID_NA": "test"
+            },
+            "customerExternalId": None
+        },
+        "_links": {},
+        "index": 0,
+        "hotSpots": [],
+        "legend": {},
+        "zones": [],
+        "date": "2024-10-21"
+    }
+    return jsonify(response)
+
+@app.route("/field-level-maps/v4/maps/management-zones-map/<string:map_type>", methods=["POST"])
+def management_zones_map(map_type):
+    if request.headers.get("accept") != "application/json" or request.headers.get("content-type") != "application/json":
+
+        return jsonify({"error": "Invalid headers"}), 400
+
+    data = request.get_json()
+    if not data or "SeasonField" not in data or "Images" not in data or "params" not in data:
+        return jsonify({"error": "Invalid request data"}), 400
+
+    zone_count = data.get('params').get("zoneCount")
+    if zone_count is None:
+        return jsonify({"error": "Invalid or missing query parameter 'zoneCount'"}), 400
+
+    response = {
+        "id": "OPs0I035tUCMwrUOqPSi4g",
+        "externalIds": {},
+        "seasonField": {
+            "id": "seasonfield_id",
+            "externalIds": {
+                "id": "1LYkyW0ykCTFTpLEYZrMr9",
+                "legacY_ID_NA": "id"
+            },
+            "customerExternalId": None
+        },
+        "_links": {},
+        "index": 0,
+        "hotSpots": [],
+        "legend": {},
+        "zones": []
+    }
+    return jsonify(response)

--- a/geosys/test/mock/mock_http_server.py
+++ b/geosys/test/mock/mock_http_server.py
@@ -1,0 +1,34 @@
+from threading import Thread
+
+import requests
+from flask import request
+
+from .geosys_api_server_app import app
+
+
+class MockApiServer(Thread):
+    """Mock a live API server"""
+
+    def __init__(self, port=5000):
+        super().__init__()
+        self.port = port
+        self.app = app
+        self.url = "http://localhost:%s" % self.port
+
+        try:
+            self.app.add_url_rule("/shutdown", view_func=self._shutdown_server)
+        except AssertionError:
+            pass
+
+    def _shutdown_server(self):
+        if "werkzeug.server.shutdown" not in request.environ:
+            raise RuntimeError("Error shutting down server")
+        request.environ["werkzeug.server.shutdown"]()
+        return "Shutting down"
+
+    def shutdown_server(self):
+        requests.get("http://localhost:%s/shutdown" % self.port)
+        self.join()
+
+    def run(self):
+        self.app.run(port=self.port)

--- a/requirements_testing.txt
+++ b/requirements_testing.txt
@@ -1,3 +1,5 @@
 # packages for tests execution:
 flake8
 pep257
+
+flask


### PR DESCRIPTION
Implementation for the mock API server to be used in testing. 

The current testing structure is prone to major issues because of depending on a production server for testing, any update on the data or credentials used from/in the production server will make the test checks to fail even if there are no changes in the plugin itself.

Example the following [commit](https://github.com/Samweli/qgis-plugin/commit/60e0c60e9847f42eb279cf9e0e7e148f8e1eb3bb) is passing in a fork but it is [failing](https://github.com/earthdaily/qgis-plugin/commit/60e0c60e9847f42eb279cf9e0e7e148f8e1eb3bb) in the main repository due to different used environment credentials.

This PR will resolve these issues and make sure the tests are independent from the remote servers and we are always testing and checking for only the plugin code and changes.