### PR TITLE
Change PR packaging workflow

### DIFF
--- a/.github/workflows/pr_package.yml
+++ b/.github/workflows/pr_package.yml
@@ -1,4 +1,4 @@
-name: Create plugin package in the PR
+name: Plugin zip package
 
 on:
   pull_request:
@@ -9,21 +9,6 @@ on:
       - synchronize
     branches:
       - develop
-
-permissions:
-  actions: write
-  attestations: write
-  checks: write
-  contents: write
-  deployments: write
-  discussions: write
-  issues: write
-  packages: write
-  pages: write
-  pull-requests: write
-  repository-projects: write
-  security-events: write
-  statuses: write
 
 jobs:
   create-package:
@@ -72,30 +57,3 @@ jobs:
         with:
           name: ${{ env.ZIP_NAME }}
           path: ${{ env.ZIP_PATH }}
-
-      - name: Find Comment
-        uses: peter-evans/find-comment@v2
-        id: find-comment
-        with:
-          issue-number: ${{ github.event.number }}
-          comment-author: 'github-actions[bot]'
-
-      - name: Update Comment
-        env:
-          HEAD_SHA: "${{ github.event.head_sha }}"
-          ARTIFACT_URL: ${{ steps.artifact-upload-step.outputs.artifact-url }}
-
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          token: ${{ github.token }}
-          issue-number: ${{ github.event.number }}
-          comment-id: ${{ steps.find-comment.outputs.comment-id }}
-          edit-mode: replace
-          body: |-
-            ![badge]
-            
-            Plugin zip package for the changes in this PR has been successfully built!.
-            
-            Download the plugin zip file here ${{ env.ARTIFACT_URL }}
-            
-            [badge]: https://img.shields.io/badge/package_build-success-green


### PR DESCRIPTION
Due to issues in the permissions inside the `GITHUB_TOKEN` , the workflow responsible for creating a plugin zip artifact and adding a comment into to PR is/was failing to add a comment that contains the plugin zip file artifact link.

This change removes the comment addition step until the permissions are sorted. Users will have to click on the workflow link and download an artifact from the workflow summary page.