### PR TITLE
Fix issue in coverage search on Windows

### DIFF
--- a/geosys/bridge_api/api_abstract.py
+++ b/geosys/bridge_api/api_abstract.py
@@ -81,9 +81,11 @@ class ApiClient(object):
         :param args: List of endpoints.
         :return: str
         """
-        full_url = self.base_url
+        full_url = self.base_url.rstrip('/')
+
         for item in args:
-            full_url = os.path.join(full_url, item)
+            full_url = f"{full_url}/{item.lstrip('/')}"
+
         return full_url
 
     def get(self, url, **kwargs):


### PR DESCRIPTION
These changes contain updates in the URL formation function which was not correctly adding a separator inside the Windows OS.

Screenshot of the coverage search working in window.
![Screenshot 2024-12-10 112509](https://github.com/user-attachments/assets/d7e2ee58-a60f-4020-917e-5439c5c33c17)
