### PR TITLE
Hotspots updates

### DIFF
--- a/geosys/bridge_api/default.py
+++ b/geosys/bridge_api/default.py
@@ -43,7 +43,7 @@ BRIDGE_URLS = {
     }
 }
 
-HOTSPOT_URL = 'https://hotspots-dev.aws-dev.geosys.com/hotspots-processor'
+HOTSPOT_URL = 'https://hotspots.aws.geosys.com/hotspots-processor'
 
 VEGETATION_ENDPOINT = 'vegetation'
 SAMZ_ENDPOINT = 'management-zones'

--- a/geosys/bridge_api/field_level_maps.py
+++ b/geosys/bridge_api/field_level_maps.py
@@ -351,16 +351,16 @@ class FieldLevelMapsAPIClient(ApiClient):
                 params=params
             )
 
-        if response:
+        if response.status_code == 200:
             return response.json()
 
-        return {}
+        return response
 
     def get_rx_map(
-        self,
-        url,
-        request_data,
-        params=None):
+            self,
+            url,
+            request_data,
+            params=None):
         """
         Get RX Map data from the server.
 
@@ -399,7 +399,7 @@ class FieldLevelMapsAPIClient(ApiClient):
         )
 
         return response.json()
-    
+
     def patch_rx_map(self, source_map_id, patch_data):
         """ Actual method to get zone hotspots.
 
@@ -411,13 +411,13 @@ class FieldLevelMapsAPIClient(ApiClient):
             'accept': 'application/json',
             'content-type': 'application/json'
         }
-        
+
         patch_url = self.full_url(
             'maps',
             source_map_id,
             'rx-map'
         )
-        
+
         response = self.patch(
             patch_url,
             headers=headers,

--- a/geosys/ui/templates/geosys_dockwidget_base.ui
+++ b/geosys/ui/templates/geosys_dockwidget_base.ui
@@ -670,55 +670,41 @@
               <bool>true</bool>
              </property>
              <layout class="QGridLayout" name="gridLayout_3">
-              <item row="0" column="0">
-               <widget class="QCheckBox" name="cb_none">
+              <item row="1" column="1">
+               <widget class="QRadioButton" name="rb_max">
                 <property name="text">
-                 <string>None</string>
-                </property>
-                <property name="checked">
-                 <bool>true</bool>
+                 <string>Maximum</string>
                 </property>
                </widget>
               </item>
               <item row="0" column="1">
-               <widget class="QCheckBox" name="cb_med">
+               <widget class="QRadioButton" name="rb_med">
                 <property name="text">
                  <string>Median</string>
                 </property>
                </widget>
               </item>
               <item row="1" column="0">
-               <widget class="QCheckBox" name="cb_point_on_surface">
-                <property name="text">
-                 <string>Point on surface</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <widget class="QCheckBox" name="cb_max">
-                <property name="text">
-                 <string>Maximum</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="0">
-               <widget class="QCheckBox" name="cb_min">
+               <widget class="QRadioButton" name="rb_min">
                 <property name="text">
                  <string>Minimum</string>
                 </property>
                </widget>
               </item>
-              <item row="2" column="1">
-               <widget class="QCheckBox" name="cb_all">
+              <item row="2" column="0">
+               <widget class="QRadioButton" name="rb_ave">
                 <property name="text">
-                 <string>All</string>
+                 <string>Average</string>
                 </property>
                </widget>
               </item>
-              <item row="3" column="0">
-               <widget class="QCheckBox" name="cb_ave">
+              <item row="0" column="0">
+               <widget class="QRadioButton" name="rb_point_on_surface">
                 <property name="text">
-                 <string>Average</string>
+                 <string>Point on surface</string>
+                </property>
+                <property name="checked">
+                 <bool>true</bool>
                 </property>
                </widget>
               </item>

--- a/geosys/ui/widgets/geosys_coverage_downloader.py
+++ b/geosys/ui/widgets/geosys_coverage_downloader.py
@@ -1219,19 +1219,14 @@ def download_field_map(
                 'NDWI',
                 'S2REP']
             samz_types = ['SAMZ']
-            topology_types = ['EROSION', 'ELEVATION', 'SLOPE']
-
             if map_type_key in vegetation_map_types:
                 base_url = f"{HOTSPOT_URL}/{VEGETATION_ENDPOINT}"
             elif map_type_key in samz_types:
                 base_url = f"{HOTSPOT_URL}/{SAMZ_ENDPOINT}"
-            elif map_type_key in topology_types:
-                base_url = f"{HOTSPOT_URL}/{ELEVATION_ENDPOINT}"
             else:
-                raise ValueError(
-                    f"Unsupported map type: "
-                    f"{map_type_key}"
-                )
+                message = (f"Hotspots support not available"
+                           f" for {map_type_key} map type ")
+                return False, message
 
             params = {
                 'Type': data.get('zoningSegmentation', 'Polygon'),

--- a/geosys/ui/widgets/geosys_dockwidget.py
+++ b/geosys/ui/widgets/geosys_dockwidget.py
@@ -153,13 +153,11 @@ class GeosysPluginDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         self.hotspot_polygon = None
         self.hotspot_polygon_part = None
         self.hotspot_position = None
-        self.hot_spot_none = None
         self.hot_spot_point_on_surface = None
         self.hot_spot_min = None
         self.hot_spot_ave = None
         self.hot_spot_med = None
         self.hot_spot_max = None
-        self.hot_spot_all = None
         self.zoning_segmentation = None
         self.output_map_format = None
         self.gain = DEFAULT_GAIN
@@ -378,7 +376,8 @@ class GeosysPluginDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
             else:
                 # Otherwise, proceed to the next page
                 self.set_zone_visibility()
-                rx_map_json = self.fetch_rx_json(self.selected_coverage_results)
+                rx_map_json = self.fetch_rx_json(
+                    self.selected_coverage_results)
                 area = self.get_areas_from_rx_map(rx_map_json)
                 self.update_zone_areas()
                 self.current_stacked_widget_index += 1
@@ -427,12 +426,12 @@ class GeosysPluginDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
                 label.show()
                 line_edit.show()
                 spinbox.show()
-                
+
     def fetch_rx_json(self, map_specifications):
         bridge_api = BridgeAPI(
             *credentials_parameters_from_settings(),
             proxies=QGISSettings.get_qgis_proxy())
-        
+
         # Extract season field and image IDs
         image_id = map_specifications[0]['image']['id']
         image_date = map_specifications[0]['image']['date']
@@ -446,17 +445,18 @@ class GeosysPluginDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         self.gain = self.spinBox_gain.value()  # Gain set by user
         self.offset = self.spinBox_offset.value()  # Offset set by user
         data = {
-                YIELD_AVERAGE: self.yield_average,
-                YIELD_MINIMUM: self.yield_minimum,
-                YIELD_MAXIMUM: self.yield_maximum,
-                ORGANIC_AVERAGE: self.organic_average,
-                SAMZ_ZONE: self.samz_zone,
-                GAIN: self.gain,
-                OFFSET: self.offset
-            }
+            YIELD_AVERAGE: self.yield_average,
+            YIELD_MINIMUM: self.yield_minimum,
+            YIELD_MAXIMUM: self.yield_maximum,
+            ORGANIC_AVERAGE: self.organic_average,
+            SAMZ_ZONE: self.samz_zone,
+            GAIN: self.gain,
+            OFFSET: self.offset
+        }
         try:
             # Call API to fetch NDVI for the selected image
-            ndvi_response = fetch_ndvi_map(season_field_geom, image_id, data=data)
+            ndvi_response = fetch_ndvi_map(
+                season_field_geom, image_id, data=data)
             if ndvi_response and 'id' in ndvi_response:
                 source_map_id = (ndvi_response['id'])
         except Exception as e:
@@ -466,15 +466,15 @@ class GeosysPluginDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
                 f'Error fetching NDVI map: {e}'
             )
             return
-        
+
         rx_map_json = bridge_api.get_rx_map(
             url=bridge_api.bridge_server,
             source_map_id=source_map_id,
             zone_count=zone_count
-            )
-        
+        )
+
         return rx_map_json
-    
+
     def get_areas_from_rx_map(self, rx_map_json):
         """Collect areas of each zone from the rx_map_json."""
         areas = []
@@ -487,22 +487,24 @@ class GeosysPluginDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
                 if 'stats' in zone and 'area' in zone['stats']:
                     areas.append(zone['stats']['area'])
         return areas
-    
+
     def update_zone_areas(self):
         """Updates the area values in the corresponding line_edit fields based on the RX zone data."""
-        
+
         # Fetch the rx_map_json and extract the areas
         rx_map_json = self.fetch_rx_json(self.selected_coverage_results)
-        areas = self.get_areas_from_rx_map(rx_map_json)  # Call the method to get areas
-        
+        areas = self.get_areas_from_rx_map(
+            rx_map_json)  # Call the method to get areas
+
         for zone_index in range(1, 21):
             # Dynamically construct object names for line edits
             line_edit_name = f"zone_{zone_index}_val"
-            
+
             # Retrieve the line_edit element using getattr
             line_edit = getattr(self, line_edit_name, None)
 
-            # Only update if the line_edit exists and the area data is available for the zone
+            # Only update if the line_edit exists and the area data is
+            # available for the zone
             if line_edit and zone_index <= len(areas):
                 area_value = areas[zone_index - 1]  # Adjust for 0-based index
                 area_in_hectares = area_value / 10000  # Convert area to hectares
@@ -815,21 +817,17 @@ class GeosysPluginDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
             self.hotspot_polygon_part = self.hotspot_polygon_part_form.isChecked()
             self.hotspot_position = self.hotspots_position_group.isChecked()
             if self.hotspot_position:
-                self.hot_spot_none = self.cb_none.isChecked()
-                self.hot_spot_point_on_surface = self.cb_point_on_surface.isChecked()
-                self.hot_spot_min = self.cb_min.isChecked()
-                self.hot_spot_ave = self.cb_ave.isChecked()
-                self.hot_spot_med = self.cb_med.isChecked()
-                self.hot_spot_max = self.cb_max.isChecked()
-                self.hot_spot_all = self.cb_all.isChecked()
+                self.hot_spot_point_on_surface = self.rb_point_on_surface.isChecked()
+                self.hot_spot_min = self.rb_min.isChecked()
+                self.hot_spot_ave = self.rb_ave.isChecked()
+                self.hot_spot_med = self.rb_med.isChecked()
+                self.hot_spot_max = self.rb_max.isChecked()
             else:
-                self.hot_spot_none = False
                 self.hot_spot_point_on_surface = False
                 self.hot_spot_min = False
                 self.hot_spot_ave = False
                 self.hot_spot_med = False
                 self.hot_spot_max = False
-                self.hot_spot_all = False
 
         # SaMZ map creation accept zero selected results, which means it will
         # trigger automatic SaMZ map creation.
@@ -998,17 +996,15 @@ class GeosysPluginDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
                 if self.hotspot_polygon_part:
                     data.update({
                         HOTSPOT: self.hotspot_polygon_part,
-                        ZONING_SEGMENTATION: 'polygon'
+                        ZONING_SEGMENTATION: 'Zone'
                     })
                 if self.hotspot_position:
                     position_values = {
-                        'none': self.hot_spot_none,
-                        'pointonsurface': self.hot_spot_point_on_surface,
-                        'min': self.hot_spot_min,
-                        'max': self.hot_spot_max,
-                        'average': self.hot_spot_ave,
-                        'median': self.hot_spot_med,
-                        'all': self.hot_spot_all
+                        'PointOnSurface': self.hot_spot_point_on_surface,
+                        'Minimum': self.hot_spot_min,
+                        'Maximum': self.hot_spot_max,
+                        'Average': self.hot_spot_ave,
+                        'Median': self.hot_spot_med,
                     }
                     position = ""
                     for key, value in position_values.items():
@@ -1160,7 +1156,6 @@ class GeosysPluginDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
                 sample_map_id = None
                 if self.map_product == SAMPLE_MAP['key']:
                     sample_map_id = map_specification['id']
-
                 is_success, message = create_map(
                     map_specification, self.map_product, geometry, self.output_directory, filename,
                     data=data, output_map_format=self.output_map_format,
@@ -1170,6 +1165,7 @@ class GeosysPluginDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
                     max_yield_val=self.yield_maximum_form.value(),
                     sample_map_id=sample_map_id
                 )
+
                 if not is_success:
                     QMessageBox.critical(
                         self,


### PR DESCRIPTION
Fixes https://github.com/earthdaily/qgis-plugin/issues/355

This PR updates the UI and functionality to support the new API for fetching hotspots on vegetation and SaMZ maps. Elevation maps are not yet supported.

**Changes**:

- Hotspot API Integration:
  Supports hotspots on vegetation and SaMZ maps (elevation maps not supported).

- UI Updates:
  Replaced checkbox with radio buttons in the "Position" group box (due to new API limitations).
  Removed the "Filter" group box.

- Layer Changes:
  Added a "value" string column in the final hotspot map layer, which now includes segmentId and value attributes.

- Error Handling:
  Improved error messages when there are issues fetching hotspots from the server. User will be notified if there an internal server error if it occurs.

Screenshot: new look of the plugin map creation tab

![image](https://github.com/user-attachments/assets/c25c959a-5fb6-4a1b-a45a-195b53a54c83)

Example hotspots creation

![geosys_hotspots_example](https://github.com/user-attachments/assets/7823d57b-bcb0-41c3-bbc5-92e62e850984)

**Notes**:
We need clarification on how the new API differentiate between hotspots for each polygon and hotspots for each polygon part if the difference is still available in the new API endpoints.




