### PR TITLE
Update hotspots position input

### DIFF
--- a/geosys/ui/templates/geosys_dockwidget_base.ui
+++ b/geosys/ui/templates/geosys_dockwidget_base.ui
@@ -667,7 +667,10 @@
               <string>Position</string>
              </property>
              <property name="checkable">
-              <bool>true</bool>
+              <bool>false</bool>
+             </property>
+             <property name="checked">
+              <bool>false</bool>
              </property>
              <layout class="QGridLayout" name="gridLayout_3">
               <item row="1" column="1">


### PR DESCRIPTION
Make the position group box uncheckable hence user should always select a position type when requesting to fetch hotspots.

Screenshot of the plugin map creation tab after update
![image](https://github.com/user-attachments/assets/d409a2a3-81e1-4df1-b5bd-f5b89cbfb192)
