### PR TITLE
Update hotspots group inputs

### DIFF
--- a/geosys/ui/templates/geosys_dockwidget_base.ui
+++ b/geosys/ui/templates/geosys_dockwidget_base.ui
@@ -655,7 +655,7 @@
              <item row="0" column="1">
               <widget class="QRadioButton" name="hotspot_polygon_part_form">
                <property name="text">
-                <string>Hot Spot (for each polygon part)</string>
+                <string>Hot Spot (for each zone)</string>
                </property>
               </widget>
              </item>


### PR DESCRIPTION
Support for polygon parts has been removed in API v5. Now the hotspots endpoints support 'Polygon' and 'Zone' types only.

Screenshot

![image](https://github.com/user-attachments/assets/799c2cbb-e67c-4b8a-8766-3b962ebe7501)
