### PR TITLE
Address limits on Rx Map values

### DIFF
--- a/geosys/ui/templates/geosys_dockwidget_base.ui
+++ b/geosys/ui/templates/geosys_dockwidget_base.ui
@@ -42,7 +42,7 @@
        </sizepolicy>
       </property>
       <property name="currentIndex">
-       <number>2</number>
+       <number>3</number>
       </property>
       <widget class="QWidget" name="coverage_form_page">
        <property name="minimumSize">
@@ -769,28 +769,8 @@
            <string>Parameters</string>
           </property>
           <layout class="QGridLayout" name="gridLayout_6">
-           <item row="0" column="1">
-            <widget class="QLabel" name="label_2">
-             <property name="text">
-              <string>Input name</string>
-             </property>
-            </widget>
-           </item>
-           <item row="6" column="0">
-            <widget class="QLabel" name="zone_x_5">
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>20</height>
-              </size>
-             </property>
-             <property name="text">
-              <string>Zone 5</string>
-             </property>
-            </widget>
-           </item>
-           <item row="20" column="1">
-            <widget class="QLineEdit" name="zone_19_val">
+           <item row="13" column="1">
+            <widget class="QLineEdit" name="zone_12_val">
              <property name="maximumSize">
               <size>
                <width>16777215</width>
@@ -799,21 +779,8 @@
              </property>
             </widget>
            </item>
-           <item row="12" column="0">
-            <widget class="QLabel" name="zone_x_11">
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>20</height>
-              </size>
-             </property>
-             <property name="text">
-              <string>Zone 11</string>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="2">
-            <widget class="QSpinBox" name="zone_2_sb">
+           <item row="19" column="2">
+            <widget class="QSpinBox" name="zone_18_sb">
              <property name="maximumSize">
               <size>
                <width>16777215</width>
@@ -821,7 +788,33 @@
               </size>
              </property>
              <property name="maximum">
-              <number>100</number>
+              <number>2147483647</number>
+             </property>
+            </widget>
+           </item>
+           <item row="10" column="2">
+            <widget class="QSpinBox" name="zone_9_sb">
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>20</height>
+              </size>
+             </property>
+             <property name="maximum">
+              <number>2147483647</number>
+             </property>
+            </widget>
+           </item>
+           <item row="20" column="2">
+            <widget class="QSpinBox" name="zone_19_sb">
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>20</height>
+              </size>
+             </property>
+             <property name="maximum">
+              <number>2147483647</number>
              </property>
             </widget>
            </item>
@@ -835,16 +828,16 @@
              </property>
             </widget>
            </item>
-           <item row="2" column="2">
-            <widget class="QSpinBox" name="zone_1_sb">
+           <item row="13" column="0">
+            <widget class="QLabel" name="zone_x_12">
              <property name="maximumSize">
               <size>
                <width>16777215</width>
                <height>20</height>
               </size>
              </property>
-             <property name="maximum">
-              <number>100</number>
+             <property name="text">
+              <string>Zone 12</string>
              </property>
             </widget>
            </item>
@@ -858,6 +851,19 @@
              </property>
             </widget>
            </item>
+           <item row="3" column="2">
+            <widget class="QSpinBox" name="zone_2_sb">
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>20</height>
+              </size>
+             </property>
+             <property name="maximum">
+              <number>2147483647</number>
+             </property>
+            </widget>
+           </item>
            <item row="16" column="2">
             <widget class="QSpinBox" name="zone_15_sb">
              <property name="maximumSize">
@@ -866,10 +872,23 @@
                <height>20</height>
               </size>
              </property>
+             <property name="maximum">
+              <number>2147483647</number>
+             </property>
             </widget>
            </item>
-           <item row="20" column="0">
-            <widget class="QLabel" name="zone_x_19">
+           <item row="9" column="1">
+            <widget class="QLineEdit" name="zone_8_val">
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>20</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item row="21" column="0">
+            <widget class="QLabel" name="zone_x_20">
              <property name="maximumSize">
               <size>
                <width>16777215</width>
@@ -877,45 +896,12 @@
               </size>
              </property>
              <property name="text">
-              <string>Zone 19</string>
+              <string>Zone 20</string>
              </property>
             </widget>
            </item>
-           <item row="21" column="2">
-            <widget class="QSpinBox" name="zone_20_sb">
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>20</height>
-              </size>
-             </property>
-            </widget>
-           </item>
-           <item row="11" column="0">
-            <widget class="QLabel" name="zone_x_10">
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>20</height>
-              </size>
-             </property>
-             <property name="text">
-              <string>Zone 10</string>
-             </property>
-            </widget>
-           </item>
-           <item row="12" column="2">
-            <widget class="QSpinBox" name="zone_11_sb">
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>20</height>
-              </size>
-             </property>
-            </widget>
-           </item>
-           <item row="7" column="2">
-            <widget class="QSpinBox" name="zone_6_sb">
+           <item row="4" column="2">
+            <widget class="QSpinBox" name="zone_3_sb">
              <property name="maximumSize">
               <size>
                <width>16777215</width>
@@ -923,12 +909,12 @@
               </size>
              </property>
              <property name="maximum">
-              <number>100</number>
+              <number>2147483647</number>
              </property>
             </widget>
            </item>
-           <item row="20" column="2">
-            <widget class="QSpinBox" name="zone_19_sb">
+           <item row="17" column="1">
+            <widget class="QLineEdit" name="zone_16_val">
              <property name="maximumSize">
               <size>
                <width>16777215</width>
@@ -956,21 +942,8 @@
              </property>
             </widget>
            </item>
-           <item row="15" column="0">
-            <widget class="QLabel" name="zone_x_14">
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>20</height>
-              </size>
-             </property>
-             <property name="text">
-              <string>Zone 14</string>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="1">
-            <widget class="QLineEdit" name="zone_2_val">
+           <item row="14" column="1">
+            <widget class="QLineEdit" name="zone_13_val">
              <property name="maximumSize">
               <size>
                <width>16777215</width>
@@ -979,28 +952,21 @@
              </property>
             </widget>
            </item>
-           <item row="10" column="1">
-            <widget class="QLineEdit" name="zone_9_val">
+           <item row="17" column="2">
+            <widget class="QSpinBox" name="zone_16_sb">
              <property name="maximumSize">
               <size>
                <width>16777215</width>
                <height>20</height>
               </size>
              </property>
-            </widget>
-           </item>
-           <item row="6" column="1">
-            <widget class="QLineEdit" name="zone_5_val">
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>20</height>
-              </size>
+             <property name="maximum">
+              <number>2147483647</number>
              </property>
             </widget>
            </item>
-           <item row="15" column="1">
-            <widget class="QLineEdit" name="zone_14_val">
+           <item row="20" column="1">
+            <widget class="QLineEdit" name="zone_19_val">
              <property name="maximumSize">
               <size>
                <width>16777215</width>
@@ -1022,8 +988,44 @@
              </property>
             </widget>
            </item>
-           <item row="18" column="0">
-            <widget class="QLabel" name="zone_x_17">
+           <item row="2" column="1">
+            <widget class="QLineEdit" name="zone_1_val">
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>20</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="2">
+            <widget class="QSpinBox" name="zone_4_sb">
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>20</height>
+              </size>
+             </property>
+             <property name="maximum">
+              <number>2147483647</number>
+             </property>
+            </widget>
+           </item>
+           <item row="15" column="2">
+            <widget class="QSpinBox" name="zone_14_sb">
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>20</height>
+              </size>
+             </property>
+             <property name="maximum">
+              <number>2147483647</number>
+             </property>
+            </widget>
+           </item>
+           <item row="7" column="0">
+            <widget class="QLabel" name="zone_x_6">
              <property name="maximumSize">
               <size>
                <width>16777215</width>
@@ -1031,7 +1033,40 @@
               </size>
              </property>
              <property name="text">
-              <string>Zone 17</string>
+              <string>Zone 6</string>
+             </property>
+            </widget>
+           </item>
+           <item row="21" column="1">
+            <widget class="QLineEdit" name="zone_20_val">
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>20</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item row="8" column="2">
+            <widget class="QSpinBox" name="zone_7_sb">
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>20</height>
+              </size>
+             </property>
+             <property name="maximum">
+              <number>2147483647</number>
+             </property>
+            </widget>
+           </item>
+           <item row="6" column="1">
+            <widget class="QLineEdit" name="zone_5_val">
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>20</height>
+              </size>
              </property>
             </widget>
            </item>
@@ -1045,8 +1080,8 @@
              </property>
             </widget>
            </item>
-           <item row="21" column="0">
-            <widget class="QLabel" name="zone_x_20">
+           <item row="17" column="0">
+            <widget class="QLabel" name="zone_x_16">
              <property name="maximumSize">
               <size>
                <width>16777215</width>
@@ -1054,12 +1089,22 @@
               </size>
              </property>
              <property name="text">
-              <string>Zone 20</string>
+              <string>Zone 16</string>
              </property>
             </widget>
            </item>
-           <item row="16" column="0">
-            <widget class="QLabel" name="zone_x_15">
+           <item row="8" column="1">
+            <widget class="QLineEdit" name="zone_7_val">
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>20</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item row="19" column="0">
+            <widget class="QLabel" name="zone_x_18">
              <property name="maximumSize">
               <size>
                <width>16777215</width>
@@ -1067,7 +1112,98 @@
               </size>
              </property>
              <property name="text">
-              <string>Zone 15</string>
+              <string>Zone 18</string>
+             </property>
+            </widget>
+           </item>
+           <item row="6" column="2">
+            <widget class="QSpinBox" name="zone_5_sb">
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>20</height>
+              </size>
+             </property>
+             <property name="maximum">
+              <number>2147483647</number>
+             </property>
+            </widget>
+           </item>
+           <item row="21" column="2">
+            <widget class="QSpinBox" name="zone_20_sb">
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>20</height>
+              </size>
+             </property>
+             <property name="maximum">
+              <number>2147483647</number>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="2">
+            <widget class="QSpinBox" name="zone_1_sb">
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>20</height>
+              </size>
+             </property>
+             <property name="maximum">
+              <number>2147483647</number>
+             </property>
+            </widget>
+           </item>
+           <item row="8" column="0">
+            <widget class="QLabel" name="zone_x_7">
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>20</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>Zone 7</string>
+             </property>
+            </widget>
+           </item>
+           <item row="11" column="0">
+            <widget class="QLabel" name="zone_x_10">
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>20</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>Zone 10</string>
+             </property>
+            </widget>
+           </item>
+           <item row="10" column="0">
+            <widget class="QLabel" name="zone_x_9">
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>20</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>Zone 9</string>
+             </property>
+            </widget>
+           </item>
+           <item row="18" column="2">
+            <widget class="QSpinBox" name="zone_17_sb">
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>20</height>
+              </size>
+             </property>
+             <property name="maximum">
+              <number>2147483647</number>
              </property>
             </widget>
            </item>
@@ -1084,8 +1220,159 @@
              </property>
             </widget>
            </item>
-           <item row="17" column="1">
-            <widget class="QLineEdit" name="zone_16_val">
+           <item row="15" column="0">
+            <widget class="QLabel" name="zone_x_14">
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>20</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>Zone 14</string>
+             </property>
+            </widget>
+           </item>
+           <item row="13" column="2">
+            <widget class="QSpinBox" name="zone_12_sb">
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>20</height>
+              </size>
+             </property>
+             <property name="maximum">
+              <number>2147483647</number>
+             </property>
+            </widget>
+           </item>
+           <item row="12" column="2">
+            <widget class="QSpinBox" name="zone_11_sb">
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>20</height>
+              </size>
+             </property>
+             <property name="maximum">
+              <number>2147483647</number>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="0">
+            <widget class="QLabel" name="zone_x_3">
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>20</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>Zone 3</string>
+             </property>
+            </widget>
+           </item>
+           <item row="18" column="1">
+            <widget class="QLineEdit" name="zone_17_val">
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>20</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="0">
+            <widget class="QLabel" name="zone_x_4">
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>20</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>Zone 4</string>
+             </property>
+            </widget>
+           </item>
+           <item row="11" column="1">
+            <widget class="QLineEdit" name="zone_10_val">
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>20</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item row="18" column="0">
+            <widget class="QLabel" name="zone_x_17">
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>20</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>Zone 17</string>
+             </property>
+            </widget>
+           </item>
+           <item row="15" column="1">
+            <widget class="QLineEdit" name="zone_14_val">
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>20</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="1">
+            <widget class="QLineEdit" name="zone_3_val">
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>20</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="2">
+            <widget class="QLineEdit" name="rx_name_line">
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>20</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item row="16" column="1">
+            <widget class="QLineEdit" name="zone_15_val">
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>20</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item row="11" column="2">
+            <widget class="QSpinBox" name="zone_10_sb">
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>20</height>
+              </size>
+             </property>
+             <property name="maximum">
+              <number>2147483647</number>
+             </property>
+            </widget>
+           </item>
+           <item row="10" column="1">
+            <widget class="QLineEdit" name="zone_9_val">
              <property name="maximumSize">
               <size>
                <width>16777215</width>
@@ -1113,88 +1400,6 @@
              </property>
             </widget>
            </item>
-           <item row="4" column="0">
-            <widget class="QLabel" name="zone_x_3">
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>20</height>
-              </size>
-             </property>
-             <property name="text">
-              <string>Zone 3</string>
-             </property>
-            </widget>
-           </item>
-           <item row="10" column="0">
-            <widget class="QLabel" name="zone_x_9">
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>20</height>
-              </size>
-             </property>
-             <property name="text">
-              <string>Zone 9</string>
-             </property>
-            </widget>
-           </item>
-           <item row="8" column="0">
-            <widget class="QLabel" name="zone_x_7">
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>20</height>
-              </size>
-             </property>
-             <property name="text">
-              <string>Zone 7</string>
-             </property>
-            </widget>
-           </item>
-           <item row="11" column="1">
-            <widget class="QLineEdit" name="zone_10_val">
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>20</height>
-              </size>
-             </property>
-            </widget>
-           </item>
-           <item row="11" column="2">
-            <widget class="QSpinBox" name="zone_10_sb">
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>20</height>
-              </size>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="1">
-            <widget class="QLineEdit" name="zone_1_val">
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>20</height>
-              </size>
-             </property>
-            </widget>
-           </item>
-           <item row="5" column="0">
-            <widget class="QLabel" name="zone_x_4">
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>20</height>
-              </size>
-             </property>
-             <property name="text">
-              <string>Zone 4</string>
-             </property>
-            </widget>
-           </item>
            <item row="14" column="2">
             <widget class="QSpinBox" name="zone_13_sb">
              <property name="maximumSize">
@@ -1203,162 +1408,26 @@
                <height>20</height>
               </size>
              </property>
-            </widget>
-           </item>
-           <item row="10" column="2">
-            <widget class="QSpinBox" name="zone_9_sb">
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>20</height>
-              </size>
-             </property>
-            </widget>
-           </item>
-           <item row="4" column="1">
-            <widget class="QLineEdit" name="zone_3_val">
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>20</height>
-              </size>
-             </property>
-            </widget>
-           </item>
-           <item row="13" column="1">
-            <widget class="QLineEdit" name="zone_12_val">
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>20</height>
-              </size>
-             </property>
-            </widget>
-           </item>
-           <item row="19" column="2">
-            <widget class="QSpinBox" name="zone_18_sb">
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>20</height>
-              </size>
-             </property>
-            </widget>
-           </item>
-           <item row="15" column="2">
-            <widget class="QSpinBox" name="zone_14_sb">
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>20</height>
-              </size>
-             </property>
-            </widget>
-           </item>
-           <item row="6" column="2">
-            <widget class="QSpinBox" name="zone_5_sb">
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>20</height>
-              </size>
-             </property>
              <property name="maximum">
-              <number>100</number>
+              <number>2147483647</number>
              </property>
             </widget>
            </item>
-           <item row="4" column="2">
-            <widget class="QSpinBox" name="zone_3_sb">
+           <item row="20" column="0">
+            <widget class="QLabel" name="zone_x_19">
              <property name="maximumSize">
               <size>
                <width>16777215</width>
                <height>20</height>
               </size>
              </property>
-             <property name="maximum">
-              <number>100</number>
-             </property>
-            </widget>
-           </item>
-           <item row="8" column="1">
-            <widget class="QLineEdit" name="zone_7_val">
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>20</height>
-              </size>
-             </property>
-            </widget>
-           </item>
-           <item row="9" column="1">
-            <widget class="QLineEdit" name="zone_8_val">
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>20</height>
-              </size>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="2">
-            <widget class="QLineEdit" name="rx_name_line">
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>20</height>
-              </size>
+             <property name="text">
+              <string>Zone 19</string>
              </property>
             </widget>
            </item>
            <item row="19" column="1">
             <widget class="QLineEdit" name="zone_18_val">
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>20</height>
-              </size>
-             </property>
-            </widget>
-           </item>
-           <item row="17" column="0">
-            <widget class="QLabel" name="zone_x_16">
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>20</height>
-              </size>
-             </property>
-             <property name="text">
-              <string>Zone 16</string>
-             </property>
-            </widget>
-           </item>
-           <item row="18" column="2">
-            <widget class="QSpinBox" name="zone_17_sb">
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>20</height>
-              </size>
-             </property>
-            </widget>
-           </item>
-           <item row="7" column="0">
-            <widget class="QLabel" name="zone_x_6">
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>20</height>
-              </size>
-             </property>
-             <property name="text">
-              <string>Zone 6</string>
-             </property>
-            </widget>
-           </item>
-           <item row="16" column="1">
-            <widget class="QLineEdit" name="zone_15_val">
              <property name="maximumSize">
               <size>
                <width>16777215</width>
@@ -1375,30 +1444,13 @@
                <height>20</height>
               </size>
              </property>
-            </widget>
-           </item>
-           <item row="14" column="1">
-            <widget class="QLineEdit" name="zone_13_val">
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>20</height>
-              </size>
+             <property name="maximum">
+              <number>2147483647</number>
              </property>
             </widget>
            </item>
-           <item row="13" column="2">
-            <widget class="QSpinBox" name="zone_12_sb">
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>20</height>
-              </size>
-             </property>
-            </widget>
-           </item>
-           <item row="13" column="0">
-            <widget class="QLabel" name="zone_x_12">
+           <item row="6" column="0">
+            <widget class="QLabel" name="zone_x_5">
              <property name="maximumSize">
               <size>
                <width>16777215</width>
@@ -1406,68 +1458,12 @@
               </size>
              </property>
              <property name="text">
-              <string>Zone 12</string>
+              <string>Zone 5</string>
              </property>
             </widget>
            </item>
-           <item row="18" column="1">
-            <widget class="QLineEdit" name="zone_17_val">
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>20</height>
-              </size>
-             </property>
-            </widget>
-           </item>
-           <item row="17" column="2">
-            <widget class="QSpinBox" name="zone_16_sb">
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>20</height>
-              </size>
-             </property>
-            </widget>
-           </item>
-           <item row="8" column="2">
-            <widget class="QSpinBox" name="zone_7_sb">
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>20</height>
-              </size>
-             </property>
-             <property name="maximum">
-              <number>100</number>
-             </property>
-            </widget>
-           </item>
-           <item row="5" column="2">
-            <widget class="QSpinBox" name="zone_4_sb">
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>20</height>
-              </size>
-             </property>
-             <property name="maximum">
-              <number>100</number>
-             </property>
-            </widget>
-           </item>
-           <item row="21" column="1">
-            <widget class="QLineEdit" name="zone_20_val">
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>20</height>
-              </size>
-             </property>
-            </widget>
-           </item>
-           <item row="19" column="0">
-            <widget class="QLabel" name="zone_x_18">
+           <item row="16" column="0">
+            <widget class="QLabel" name="zone_x_15">
              <property name="maximumSize">
               <size>
                <width>16777215</width>
@@ -1475,7 +1471,50 @@
               </size>
              </property>
              <property name="text">
-              <string>Zone 18</string>
+              <string>Zone 15</string>
+             </property>
+            </widget>
+           </item>
+           <item row="12" column="0">
+            <widget class="QLabel" name="zone_x_11">
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>20</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>Zone 11</string>
+             </property>
+            </widget>
+           </item>
+           <item row="7" column="2">
+            <widget class="QSpinBox" name="zone_6_sb">
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>20</height>
+              </size>
+             </property>
+             <property name="maximum">
+              <number>2147483647</number>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="1">
+            <widget class="QLineEdit" name="zone_2_val">
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>20</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QLabel" name="label_2">
+             <property name="text">
+              <string>Input name</string>
              </property>
             </widget>
            </item>


### PR DESCRIPTION
Fixes https://github.com/earthdaily/qgis-plugin/issues/401

Updates the Rx map spin box maximum values input, now sets it to the maximum allowed number `2147483647`.

Screenshot

![image](https://github.com/user-attachments/assets/e6bb34b1-07fc-4663-a646-b6d24b76616b)
