### PR TITLE
Include position parameter in vegetation hotspots

### DIFF
--- a/geosys/ui/widgets/geosys_coverage_downloader.py
+++ b/geosys/ui/widgets/geosys_coverage_downloader.py
@@ -1266,6 +1266,7 @@ def download_field_map(
         else:
             destination_filename = (
                 destination_base_path + output_map_format['extension'])
+
             fetch_data(url, destination_filename, headers=headers)
             if output_map_format == PNG or output_map_format == PNG_KMZ:
                 # Download associated legend and world-file for geo-referencing
@@ -1360,8 +1361,9 @@ def download_field_map(
                 hotspot_filename = (
                     f"{'HotspotsPerPart' if params['Type'] == 'Polygon' else 'HotspotsPerPolygon'}_"
                     f"{params.get('Position').lower() if params.get('Position') else ''}_"
-                    f"{str(request_body.get('image_id')[0])[:4]}_"
-                    f"{str(uuid.uuid4())[:4]}")
+                    f"{str(request_body.get('image_id')[0])[:4] or ''}_"
+                    f"{str(uuid.uuid4())[:4] or ''}")
+
                 hotspot_filename = check_if_file_exists(
                     output_dir, hotspot_filename, SHP_EXT)
 
@@ -1376,8 +1378,9 @@ def download_field_map(
                 segment_filename = (
                     f"{'SegmentsPerPart' if params['Type'] == 'Polygon' else 'SegmentsPerPolygon'}_"
                     f"{params.get('Position').lower() if params.get('Position') else ''}_"
-                    f"{str(request_body.get('image_id')[0])[:4]}_"
-                    f"{str(uuid.uuid4())[:4]}")
+                    f"{str(request_body.get('image_id')[0])[:4] or ''}_"
+                    f"{str(uuid.uuid4())[:4] or ''}")
+
                 segment_filename = check_if_file_exists(
                     output_dir, segment_filename, SHP_EXT)
 

--- a/geosys/ui/widgets/geosys_dockwidget.py
+++ b/geosys/ui/widgets/geosys_dockwidget.py
@@ -153,11 +153,11 @@ class GeosysPluginDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         self.hotspot_polygon = None
         self.hotspot_polygon_part = None
         self.hotspot_position = None
-        self.hot_spot_point_on_surface = None
-        self.hot_spot_min = None
-        self.hot_spot_ave = None
-        self.hot_spot_med = None
-        self.hot_spot_max = None
+        self.hot_spot_point_on_surface = True
+        self.hot_spot_min = False
+        self.hot_spot_ave = False
+        self.hot_spot_med = False
+        self.hot_spot_max = False
         self.zoning_segmentation = None
         self.output_map_format = None
         self.gain = DEFAULT_GAIN
@@ -817,19 +817,12 @@ class GeosysPluginDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         if self.hotspot_fetch:
             self.hotspot_polygon = self.hotspot_polygon_form.isChecked()
             self.hotspot_polygon_part = self.hotspot_polygon_part_form.isChecked()
-            self.hotspot_position = self.hotspots_position_group.isChecked()
-            if self.hotspot_position:
-                self.hot_spot_point_on_surface = self.rb_point_on_surface.isChecked()
-                self.hot_spot_min = self.rb_min.isChecked()
-                self.hot_spot_ave = self.rb_ave.isChecked()
-                self.hot_spot_med = self.rb_med.isChecked()
-                self.hot_spot_max = self.rb_max.isChecked()
-            else:
-                self.hot_spot_point_on_surface = False
-                self.hot_spot_min = False
-                self.hot_spot_ave = False
-                self.hot_spot_med = False
-                self.hot_spot_max = False
+
+            self.hot_spot_point_on_surface = self.rb_point_on_surface.isChecked()
+            self.hot_spot_min = self.rb_min.isChecked()
+            self.hot_spot_ave = self.rb_ave.isChecked()
+            self.hot_spot_med = self.rb_med.isChecked()
+            self.hot_spot_max = self.rb_max.isChecked()
 
         # SaMZ map creation accept zero selected results, which means it will
         # trigger automatic SaMZ map creation.
@@ -1001,23 +994,21 @@ class GeosysPluginDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
                         HOTSPOT: self.hotspot_polygon_part,
                         ZONING_SEGMENTATION: 'Zone'
                     })
-                if self.hotspot_position:
-                    position_values = {
-                        'PointOnSurface': self.hot_spot_point_on_surface,
-                        'Minimum': self.hot_spot_min,
-                        'Maximum': self.hot_spot_max,
-                        'Average': self.hot_spot_ave,
-                        'Median': self.hot_spot_med,
-                    }
-                    position = ""
-                    for key, value in position_values.items():
-                        if value:
-                            position = f"{position}{key} "
-                    position = position.rstrip()
-                    position = position.replace(' ', '|')
-                    data.update({
-                        POSITION: position
-                    })
+
+                position_values = {
+                    'PointOnSurface': self.hot_spot_point_on_surface,
+                    'Minimum': self.hot_spot_min,
+                    'Maximum': self.hot_spot_max,
+                    'Average': self.hot_spot_ave,
+                    'Median': self.hot_spot_med,
+                }
+                position = 'Average'
+                for key, value in position_values.items():
+                    if value:
+                        position = f"{key}"
+                data.update({
+                    POSITION: position
+                })
 
         zone_cnt = self.samz_zone_form.value()
         if map_product_definition == SAMZ:

--- a/geosys/ui/widgets/geosys_dockwidget.py
+++ b/geosys/ui/widgets/geosys_dockwidget.py
@@ -1115,9 +1115,10 @@ class GeosysPluginDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
                 filename = '{}_{}_zones_{}_{}'.format(
                     self.map_product,  # map_specification['maps'][0]['type'],
                     str(zone_cnt),
-                    map_specification['seasonField']['id'],
-                    map_specification['image']['date']
+                    map_specification['seasonField']['id'] or '',
+                    map_specification['image']['date'] or ''
                 )
+
                 filename = clean_filename(filename)
                 filename = check_if_file_exists(
                     self.output_directory,

--- a/geosys/ui/widgets/geosys_dockwidget.py
+++ b/geosys/ui/widgets/geosys_dockwidget.py
@@ -1006,6 +1006,7 @@ class GeosysPluginDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
                 for key, value in position_values.items():
                     if value:
                         position = f"{key}"
+                        break
                 data.update({
                     POSITION: position
                 })


### PR DESCRIPTION
Fixes https://github.com/earthdaily/qgis-plugin/issues/420

Adds the missing position parameter when fetching hotspots .

Screenshot

![hotspot_position_fix](https://github.com/user-attachments/assets/f832206d-b9a0-4e18-a6f6-cd4125b8b53f)
